### PR TITLE
PADV-303: LTI launch complete course rendering ADR

### DIFF
--- a/docs/decisions/0001-launch-complete-course.rst
+++ b/docs/decisions/0001-launch-complete-course.rst
@@ -259,8 +259,7 @@ Workflow
 1. A new view will receive the IDs of the requested content.
 2. We will validate that the requested IDs are valid and that the user on the request
    have an LTIPRofile instance.
-3. If the user has no permission, then the view returns nothing, if the user
-   is not enrolled in the course, also no content should be rendered.
+3. If the user has no permission, then the view returns nothing.
 4. If the user has permission to load the view, we will call the render_xblock view
    to render the requested XBlock to the user alongside a navigation menu with
    the course outline. (This could be done by either injecting the XBlock using


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-303

## Description

This PR adds an ADR document where we will address the issue on the ticket PADV-303,
the document contains information on rending a whole course from and LTI course,
these are a description of the multiple approaches to achieve this, its workflow,
and each pros and cons. We will use this ADR to discuss on which approach use to
render the whole course.

## Type of Change

- Add ADR /docs/decisions/0001-launch-complete-course.rst with discovery on
  rendering a whole course for an LTI launch.