### PR TITLE
PADV-351: Add LTI XBlock and Courseware views

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,27 +1,53 @@
 openedx-lti-tool-plugin
 #######################
 
-Purpose
-*******
+Support for LTI 1.3 tool resource link launches and services.
 
-Support for LTI tool launches and services.
 Getting Started
 ***************
 
-Developing
-==========
+Installation on Open edX Devstack
+=================================
 
-One Time Setup
---------------
-.. code-block::
+- Install the Olive version of the Open edX devstack
 
-  # Clone the repository
+- Clone this repository:
+
+.. code-block:: bash
+
+  cd ~openedx/src/  # Assuming that devstack is in  ~/openedx/devstack/
   git clone git@github.com:Pearson-Advance/openedx-lti-tool-plugin.git
-  cd openedx-lti-tool-plugin
 
-  # Set up a virtualenv
+- Install plugin on your server (in this case the devstack docker lms shell):
+
+.. code-block:: bash
+
+  cd ~openedx/devstack/  # Change for your devstack path (if you are using devstack)
+  make lms-shell  # Shell into the lms container (or server where lms process runs)
+  pip install -e /edx/src/openedx-lti-tool-plugin
+  /edx/app/edxapp/edx-platform/manage.py lms migrate openedx_lti_tool_plugin # Run plugin migrations
+
+- Set the lms setting OLTITP_ENABLE_LTI_TOOL to True
+
+Development Setup
+=================
+
+- Clone this repository
+
+.. code-block:: bash
+
+  git clone git@github.com:Pearson-Advance/openedx-lti-tool-plugin.git
+
+- Set up a virtualenv
+
+.. code-block:: bash
+
+  cd openedx-lti-tool-plugin
   virtualenv venv
   source venv/bin/activate
 
-  # Install dependencies
-  make requirements
+- Install development dependencies.
+
+.. code-block:: bash
+
+  make dev-requirements

--- a/openedx_lti_tool_plugin/apps.py
+++ b/openedx_lti_tool_plugin/apps.py
@@ -10,8 +10,8 @@ class OpenEdxLtiToolPluginConfig(AppConfig):
     plugin_app = {
         'url_config': {
             'lms.djangoapp': {
-                'namespace': 'openedx_lti_tool_plugin',
-                'regex': '^openedx_lti_tool_plugin/',
+                'namespace': name,
+                'regex': f'^{name}/',
                 'relative_path': 'urls',
             },
         },

--- a/openedx_lti_tool_plugin/edxapp_wrapper/__init__.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/__init__.py
@@ -1,0 +1,1 @@
+"""Wrapper to import utilities from edx-platform."""

--- a/openedx_lti_tool_plugin/edxapp_wrapper/backends/__init__.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Backends for edx-platform modules."""

--- a/openedx_lti_tool_plugin/edxapp_wrapper/backends/courseware_module_o_v1.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/backends/courseware_module_o_v1.py
@@ -1,0 +1,12 @@
+"""courseware module backend (olive v1)."""
+from lms.djangoapps.courseware.views.views import render_xblock  # pylint: disable=import-error
+
+
+def render_xblock_backend(*args: tuple, **kwargs: dict):
+    """Return render_xblock function.
+
+    Args:
+        *args: Variable length argument list.
+        **kwargs: Arbitrary keyword arguments.
+    """
+    return render_xblock(*args, **kwargs)

--- a/openedx_lti_tool_plugin/edxapp_wrapper/courseware_module.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/courseware_module.py
@@ -1,0 +1,16 @@
+"""edx-platform courseware module wrapper."""
+from importlib import import_module
+
+from django.conf import settings
+
+
+def render_xblock(*args: tuple, **kwargs: dict):
+    """Return render_xblock function.
+
+    Args:
+        *args: Variable length argument list.
+        **kwargs: Arbitrary keyword arguments.
+    """
+    return import_module(
+        settings.OLTITP_COURSEWARE_BACKEND
+    ).render_xblock_backend(*args, **kwargs)

--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -36,5 +36,8 @@ def plugin_settings(settings: LazySettings):
     For more information please see:
     https://github.com/openedx/edx-django-utils/tree/master/edx_django_utils/plugins
     """
-    settings.OLTTP_ENABLE_LTI_TOOL = False
+    settings.OLTITP_ENABLE_LTI_TOOL = False
     settings.AUTHENTICATION_BACKENDS.append('openedx_lti_tool_plugin.auth.LtiAuthenticationBackend')
+
+    # Backends settings
+    settings.OLTITP_COURSEWARE_BACKEND = 'openedx_lti_tool_plugin.edxapp_wrapper.backends.courseware_module_o_v1'

--- a/openedx_lti_tool_plugin/settings/test.py
+++ b/openedx_lti_tool_plugin/settings/test.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 from .common import *  # pylint: disable=unused-wildcard-import,wildcard-import
 
+# Django settings
 DEBUG = True
 
 INSTALLED_APPS = [
@@ -54,4 +55,13 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTHENTICATION_BACKENDS = ['openedx_lti_tool_plugin.auth.LtiAuthenticationBackend']
 
-OLTTP_ENABLE_LTI_TOOL = True
+
+# Plugin settings
+OLTITP_ENABLE_LTI_TOOL = True
+
+COURSE_ID_PATTERN = '(?P<course_id>.*)'
+
+USAGE_KEY_PATTERN = '(?P<usage_key_string>.*)'
+
+# Backends for tests
+OLTITP_COURSEWARE_BACKEND = 'openedx_lti_tool_plugin.tests.backends_for_tests'

--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/courseware.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/courseware.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang='{{ request.LANGUAGE_CODE }}'>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <title>LTI Courseware</title>
+  </head>
+  <body>
+    <iframe
+      id='unit-iframe'
+      src='{{ xblock_url }}'
+      style='width: 100%;border: none;display: block;'>
+    </iframe>
+    <script>
+      // Detect Window.postMessage() sent from
+      // template courseware/courseware-chromeless.html.
+      window.addEventListener('message', (event)=>{
+        // Validate event origin is from LMS.
+        if (event.origin !== '{{ lms_root_url }}'){
+          return;
+        }
+        // Resize XBlock iframe on plugin.resize event.
+        if (event.data.type === 'plugin.resize'){
+          document.getElementById('unit-iframe').height = event.data.payload.height;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/openedx_lti_tool_plugin/tests/__init__.py
+++ b/openedx_lti_tool_plugin/tests/__init__.py
@@ -3,3 +3,6 @@
 ISS = 'http://foo.example.com/'
 SUB = 'random-sub'
 AUD = 'random.aud.app'
+
+COURSE_ID = 'random-course-id'
+USAGE_KEY = 'random-usage-key'

--- a/openedx_lti_tool_plugin/tests/backends_for_tests.py
+++ b/openedx_lti_tool_plugin/tests/backends_for_tests.py
@@ -1,0 +1,12 @@
+"""Test backends for the openedx_lti_tool_plugin module."""
+from unittest.mock import Mock
+
+
+def render_xblock_backend(*args: tuple, **kwargs: dict):
+    """Return render_xblock mock function.
+
+    Args:
+        *args: Variable length argument list.
+        **kwargs: Arbitrary keyword arguments.
+    """
+    return Mock()

--- a/openedx_lti_tool_plugin/tests/test_apps.py
+++ b/openedx_lti_tool_plugin/tests/test_apps.py
@@ -2,13 +2,11 @@
 from django.test import TestCase
 from jsonschema import validate
 
-from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as AppConfig
 
 
 class TestOpenEdxLtiToolPluginConfig(TestCase):
     """Test openedx_lti_tool_plugin app config."""
-
-    config = OpenEdxLtiToolPluginConfig
 
     def test_plugin_app_schema(self):
         """
@@ -54,4 +52,6 @@ class TestOpenEdxLtiToolPluginConfig(TestCase):
             },
         }
 
-        validate(instance=self.config.plugin_app, schema=schema)
+        validate(instance=AppConfig.plugin_app, schema=schema)
+        self.assertEqual(AppConfig.name, 'openedx_lti_tool_plugin')
+        self.assertEqual(AppConfig.verbose_name, 'Open edX LTI Tool Plugin')

--- a/openedx_lti_tool_plugin/tests/test_urls.py
+++ b/openedx_lti_tool_plugin/tests/test_urls.py
@@ -2,7 +2,14 @@
 from django.test import TestCase
 from django.urls import resolve, reverse
 
-from openedx_lti_tool_plugin.views import LtiToolJwksView, LtiToolLaunchView, LtiToolLoginView
+from openedx_lti_tool_plugin.tests import COURSE_ID, USAGE_KEY
+from openedx_lti_tool_plugin.views import (
+    LtiCoursewareView,
+    LtiToolJwksView,
+    LtiToolLaunchView,
+    LtiToolLoginView,
+    LtiXBlockView,
+)
 
 
 class TestUrls(TestCase):
@@ -10,12 +17,35 @@ class TestUrls(TestCase):
 
     def test_lti_tool_login_url_resolves(self):
         """Test LtiToolLoginView URL can be resolved."""
-        self.assertEqual(resolve(reverse('lti1p3-login')).func.view_class, LtiToolLoginView)
+        self.assertEqual(
+            resolve(reverse('lti1p3-login')).func.view_class,
+            LtiToolLoginView,
+        )
 
     def test_lti_tool_launch_url_resolves(self):
         """Test LtiToolLaunchView URL can be resolved."""
-        self.assertEqual(resolve(reverse('lti1p3-launch')).func.view_class, LtiToolLaunchView)
+        self.assertEqual(
+            resolve(reverse('lti1p3-launch', args=[COURSE_ID])).func.view_class,
+            LtiToolLaunchView,
+        )
 
     def test_lti_tool_jwks_url_resolves(self):
         """Test LtiToolLoginView URL can be resolved."""
-        self.assertEqual(resolve(reverse('lti1p3-pub-jwks')).func.view_class, LtiToolJwksView)
+        self.assertEqual(
+            resolve(reverse('lti1p3-pub-jwks')).func.view_class,
+            LtiToolJwksView,
+        )
+
+    def test_lti_xblock_url_resolves(self):
+        """Test LtiXBlockView URL can be resolved."""
+        self.assertEqual(
+            resolve(reverse('lti-xblock', args=[USAGE_KEY])).func.view_class,
+            LtiXBlockView,
+        )
+
+    def test_lti_courseware_url_resolves(self):
+        """Test LtiCoursewareView URL can be resolved."""
+        self.assertEqual(
+            resolve(reverse('lti-courseware', args=[USAGE_KEY])).func.view_class,
+            LtiCoursewareView,
+        )

--- a/openedx_lti_tool_plugin/urls.py
+++ b/openedx_lti_tool_plugin/urls.py
@@ -1,10 +1,27 @@
 """URL configuration for openedx_lti_tool_plugin."""
-from django.urls import path
+from django.conf import settings
+from django.urls import include, path, re_path
 
 from openedx_lti_tool_plugin import views
 
 urlpatterns = [
-    path('1.3/login/', views.LtiToolLoginView.as_view(), name='lti1p3-login'),
-    path('1.3/launch/', views.LtiToolLaunchView.as_view(), name='lti1p3-launch'),
-    path('1.3/pub/jwks/', views.LtiToolJwksView.as_view(), name='lti1p3-pub-jwks'),
+    path('1.3/', include([
+        path('login', views.LtiToolLoginView.as_view(), name='lti1p3-login'),
+        path('pub/jwks', views.LtiToolJwksView.as_view(), name='lti1p3-pub-jwks'),
+        re_path(
+            fr'^launch/{settings.COURSE_ID_PATTERN}$',
+            views.LtiToolLaunchView.as_view(),
+            name='lti1p3-launch',
+        ),
+    ])),
+    re_path(
+        fr'^xblock/{settings.USAGE_KEY_PATTERN}$',
+        views.LtiXBlockView.as_view(),
+        name='lti-xblock',
+    ),
+    re_path(
+        r'^course/(?P<unit_key>[^/]*)$',
+        views.LtiCoursewareView.as_view(),
+        name='lti-courseware',
+    ),
 ]


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-351

## Description

This PR adds XBlock and Courseware views for course LTI launches, this will allow us to have our own endpoints to render the course content for LTI launches with only the unit content. To achieve this we used the render_xblock function from edx-platform.

## Type of Change

- [x] Add LTI XBlock and Courseware views
- [x] Add courseware.html template.
- [x] Add edxapp_wrapper module.
- [x] Add courseware module wrapper backend.
- [x] Add OLTITP_COURSEWARE_BACKEND setting.
- [x] Add required edx-platform test settings.
- [x] Imported render_xblock from edx-platform.
- [x] Modify LtiToolLaunchView post method params.
- [x] Remove usage_key from LtiToolLaunchView.
- [x] Update LtiToolLaunchView tests.
- [x] Include LtiXBlockView and LtiCoursewareView tests
- [x] Update urls module tests.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
    # Enable LTI Tool Provider Plugin.
    OLTITP_ENABLE_LTI_TOOL = True
```
- Go to http://localhost:18000/openedx_lti_tool_plugin/course/unit_usage_key (Replace unit_usage_key with a XBlock ID of course unit).
- The browser should display the requested content on an iframe using the courseware.html template.

## Note

Currently the template only displays the content, we still need to render the course outline to let the user navigate the course, we also need to add the course home to make LTI 1.3 launches redirect the users to it.

The XBlock and Courseware views are only able to display units properly, other types of XBlock either don't render or render a broken navigation menu.

## Reviewers

- [x] @Squirrel18 
- [x] @Jacatove 
- [x] @alexjmpb 
- [x] @anfbermudezme 