### PR TITLE
PADV 381 - Render courseware navigation

### DIFF
--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_home.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_home.html
@@ -6,7 +6,9 @@
 <div class='container-fluid container-lg my-4 my-xl-5'>
   <div class='row'>
     <div class='col-xl-9 col-12'>
-    {% include 'openedx_lti_tool_plugin/course_outline.html' %}
+      <div id='course_title' class='h2'>{{ course_outline.display_name }}</div>
+      <hr>
+      {% include 'openedx_lti_tool_plugin/course_outline.html' %}
     </div>
   </div>
 </div>

--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_outline.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_outline.html
@@ -1,14 +1,17 @@
-<div id='course_title' class='h2'>{{ course_outline.display_name }}</div>
-<hr>
 <div id='outline' class='list-group'>
 {% for chapter in course_outline.children %}
   {% include 'openedx_lti_tool_plugin/course_outline_item.html' with block=chapter %}
-  <div id='{{ chapter.id|urlencode }}-collapse' class='list-group collapse show'>
+  <div id='{{ chapter.id|urlencode }}-collapse' class='list-group chapter-collapse collapse show'>
   {% for sequence in chapter.children %}
     {% include 'openedx_lti_tool_plugin/course_outline_item.html' with block=sequence %}
-    <div id='{{ sequence.id|urlencode }}-collapse' class='list-group collapse'>
+    <div id='{{ sequence.id|urlencode }}-collapse' class='list-group sequence-collapse collapse'>
     {% for unit in sequence.children %}
-      {% include 'openedx_lti_tool_plugin/course_outline_item.html' with block=unit %}
+      {% if unit.id == unit_obj.id %}
+        {% include 'openedx_lti_tool_plugin/course_outline_item.html' with block=unit is_active=True %}
+        <script>document.getElementById('{{sequence.id|urlencode}}-collapse').classList.add('show');</script>
+      {% else %}
+        {% include 'openedx_lti_tool_plugin/course_outline_item.html' with block=unit %}
+      {% endif %}
     {% endfor %}
     </div>
   {% endfor %}

--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_outline_item.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/course_outline_item.html
@@ -1,8 +1,8 @@
 <a
   id='{{ block.id|urlencode }}'
-  class='{{ block.type }}-item list-group-item list-group-item-action'
+  class='{{ block.type }}-item list-group-item list-group-item-action {% if is_active %}active{% endif %}'
   {% if block.type == 'vertical' %}
-  href={% url request.resolver_match.app_name|add:':lti-xblock' block.id %}
+  href={% url request.resolver_match.app_name|add:':lti-courseware' course_id block.id%}
   {% else %}
   href="#{{ block.id|urlencode }}-collapse"
   {% endif %}
@@ -11,9 +11,6 @@
   aria-controls='{{ block.id|urlencode }}-collapse'
   aria-expanded='false'
   {% endif %}>
-  <i
-  class='fa fa-{% if block.type == 'vertical' %}circle{% else %}folder{% endif %}-o'
-  aria-hidden='true'>
-  </i>
+  <i class='fa fa-{% if block.type == "vertical" %}circle{% else %}folder{% endif %}-o' aria-hidden='true'></i>
   {{ block.display_name }}
 </a>

--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/courseware.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/courseware.html
@@ -1,27 +1,155 @@
 {% extends 'openedx_lti_tool_plugin/base.html' %}
+{% load i18n %}
 
-{% block title %}LTI Courseware{% endblock %}
-
+{% block title %}{% translate 'LTI Courseware' %}{% endblock %}
 {% block body %}
-<iframe
-  id='unit-iframe'
-  src='{{ xblock_url }}'
-  style='width: 100%;border: none;display: block;'
-  scrolling='no'>
-</iframe>
-
+<div class='container-fluid container-lg my-4 my-xl-5'>
+  <main>
+    <button type='button' class='btn btn-secondary' data-bs-toggle='offcanvas' data-bs-target='#courseSidebar' aria-controls='courseSidebar'>
+      <i class='fa fa-bars' aria-hidden='true'></i> {% translate 'Course Outline' %}
+    </button>
+    <iframe id='unit-iframe' class='w-100 border-0 d-block' src='{% url request.resolver_match.app_name|add:":lti-xblock" unit_obj.id%}' scrolling='no'></iframe>
+    <div class='d-flex gap-2 justify-content-center align-items-center'>
+      <button onclick='goToPreviousUnit()' class='btn btn-outline-secondary btn-previous px-4'>
+        <i class='fa fa-chevron-left' aria-hidden='true'></i> {% translate 'Previous' %}
+      </button>
+      <button onclick='goToNextUnit()' class='btn btn-outline-secondary btn-next px-4'>
+        {% translate 'Next' %} <i class='fa fa-chevron-right' aria-hidden='true'></i>
+      </button>
+    </div>
+  </main>
+  <aside id='courseSidebar' class='offcanvas offcanvas-start' data-bs-scroll='true' aria-labelledby='courseSidebarLabel' tabindex='-1'>
+    <div class='offcanvas-header'>
+      <h3 class='offcanvas-title' id='courseSidebarLabel'>{{ course_outline.display_name }}</h3>
+      <button type='button' class='btn-close' data-bs-dismiss='offcanvas' aria-label='{% translate "Close" %}'></button>
+    </div>
+    <div class='offcanvas-body'>
+      {% include 'openedx_lti_tool_plugin/course_outline.html' %}
+    </div>
+  </aside>
+</div>
 <script>
+  const baseUrl = '{{ request.scheme }}://{{ request.get_host }}';
+  const appName = '{{ request.resolver_match.app_name }}';
+  const iframeElem = document.getElementById('unit-iframe');
+  const prevBtnElem = document.querySelector('.btn-previous');
+  const nextBtnElem = document.querySelector('.btn-next');
+  const units = {{ units|safe }};
+  let currentUnitId = '{{ unit_obj.id }}';
+
+  /**
+   * Goes to the previous unit updating the iframe.
+   *
+   * @return {void}
+   */
+  function goToPreviousUnit() {
+    // Update iframe if current unit is not first unit.
+    if (!isFirstUnit) {
+      updateUnitIframe(units[units.indexOf(currentUnitId) - 1]);
+    };
+  };
+
+  /**
+   * Goes to the next unit and updates the iframe.
+   *
+   * @returns {void}
+   */
+  function goToNextUnit() {
+    // Update iframe if current unit is not last unit.
+    if (!isLastUnit) {
+      updateUnitIframe(units[units.indexOf(currentUnitId) + 1]);
+    };
+  };
+
+  /**
+   * Checks the position of a unit in the course outline.
+   *
+   * This function determines if the given unit ID is the first or last unit in the course outline
+   * and returns an array of boolean values accordingly.
+   *
+   * @param {string} unitId - The ID of the unit to check.
+   * @returns {Array<boolean>} A tuple of booleans representing whether the unit is the first or last unit.
+   */
+  function checkUnitPosition(unitId) {
+    // Check position of unit ID on course outline.
+    let isFirstUnit = units.indexOf(unitId) > 0 ? false : true;
+    let isLastUnit = units.indexOf(unitId) < units.length -1 ? false : true;
+    // Toggle disable attribute on next and previous navigation buttons.
+    isFirstUnit ? prevBtnElem.setAttribute('disabled', '') : prevBtnElem.removeAttribute('disabled');
+    isLastUnit ? nextBtnElem.setAttribute('disabled', '') : nextBtnElem.removeAttribute('disabled');
+
+    return [isFirstUnit, isLastUnit];
+  };
+
+  /**
+   * Updates the active unit on the course outline and collapses the corresponding chapter and sequence divs.
+   *
+   * @param {string} unitId - The ID of the unit to be updated.
+   * @returns {void}
+   */
+  function updateActiveOutlineUnit(unitId) {
+    const unitBtnElem = document.getElementById(unitId);
+    // Remove active class from previously active unit.
+    document.querySelector('.vertical-item.active').classList.remove('active');
+    // Remove show from all collapse elements on outline.
+    document.getElementById('outline').querySelectorAll('.collapse').forEach(function (element) {
+      element.classList.remove('show');
+    });
+    // Add active class to unit button.
+    unitBtnElem.classList.add('active');
+    // Expand current unit chapter and sequence div.
+    unitBtnElem.closest('.chapter-collapse').classList.add('show');
+    unitBtnElem.closest('.sequence-collapse').classList.add('show');
+  };
+
+  /**
+   * Updates the iframe with the content of the given unit.
+   *
+   * This function updates the iframe source to display the content of the unit with the specified ID. It also
+   * updates the active unit on the course outline and modifies the browser history to reflect the new unit ID.
+   *
+   * @param {string} unitId - The ID of the unit to update.
+   * @returns {void}
+   */
+  function updateUnitIframe(unitId) {
+    // Decode URL encoded unit ID.
+    const decodedUnitId = decodeURIComponent(unitId);
+    // Update current unit ID and iframe src.
+    currentUnitId = decodedUnitId;
+    iframeElem.src = `${baseUrl}/${appName}/xblock/${decodedUnitId}`;
+    // Update active unit on course outline.
+    updateActiveOutlineUnit(encodeURIComponent(decodedUnitId));
+    // Update unit position state.
+    [isFirstUnit, isLastUnit] = checkUnitPosition(decodedUnitId);
+    // Update path and title to new unit ID.
+    history.pushState({}, null, `/${appName}/course/{{ course_id }}/${decodedUnitId}`);
+  };
+
+  // Update disable attribute of bottom navigation buttons on load.
+  let [isFirstUnit, isLastUnit] = checkUnitPosition(currentUnitId);
+
+  // Add click event listener to each unit on course outline.
+  document.querySelectorAll('.vertical-item').forEach(element => {
+    element.addEventListener('click', (e) => {
+      e.preventDefault();
+      // Update iframe with new unit.
+      updateUnitIframe(e.target.id);
+      // Hide course outline offcanvas.
+      bootstrap.Offcanvas.getInstance(document.getElementById('courseSidebar')).hide();
+    });
+  });
+
   // Detect Window.postMessage() sent from
   // template courseware/courseware-chromeless.html.
-  window.addEventListener('message', (event)=>{
+  window.addEventListener('message', (event) => {
     // Validate event origin is from LMS.
-    if (event.origin !== '{{ request.scheme }}://{{ request.get_host }}'){
+    if (event.origin !== baseUrl) {
       return;
-    }
+    };
     // Resize XBlock iframe on plugin.resize event.
-    if (event.data.type === 'plugin.resize'){
-      document.getElementById('unit-iframe').height = event.data.payload.height;
-    }
+    if (event.data.type === 'plugin.resize') {
+      iframeElem.height = event.data.payload.height;
+    };
   });
 </script>
 {% endblock %}

--- a/openedx_lti_tool_plugin/tests/test_urls.py
+++ b/openedx_lti_tool_plugin/tests/test_urls.py
@@ -47,7 +47,7 @@ class TestUrls(TestCase):
     def test_lti_courseware_url_resolves(self):
         """Test LtiCoursewareView URL can be resolved."""
         self.assertEqual(
-            resolve(reverse('lti-courseware', args=[USAGE_KEY])).func.view_class,
+            resolve(reverse('lti-courseware', args=[COURSE_ID, USAGE_KEY])).func.view_class,
             LtiCoursewareView,
         )
 

--- a/openedx_lti_tool_plugin/urls.py
+++ b/openedx_lti_tool_plugin/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name='lti-course-home',
     ),
     re_path(
-        r'^course/(?P<unit_key>[^/]*)$',
+        fr'^course/{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}$',
         views.LtiCoursewareView.as_view(),
         name='lti-courseware',
     ),


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-381

## Description

This PR aims to add the functionality of navigating though the course while inside the courseware

## Type of Change

- [x] Integrate the course outline in the courseware as a sidebar.
- [x] Add responsiveness to the sidebar.
- [x] Add next and previous buttons to change units.

## Screenshots:

[Screencast from 24-07-23 11:03:56.webm](https://github.com/Pearson-Advance/openedx-lti-tool-plugin/assets/62396424/a6268ff4-b924-4b40-b330-48f5061242b7)
[Screencast from 24-07-23 11:08:54.webm](https://github.com/Pearson-Advance/openedx-lti-tool-plugin/assets/62396424/71f2d248-637b-443e-9a2e-9b70d51e5b9e)



## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should work and you should be able to step into a unit and verify that the courseware and sidebar are working properly.
- Repeat the last two steps but use the "Open in new window" option on the dropdown menu.

## Reviewers

- [ ] @Squirrel18 
- [x] @kuipumu  