### PR TITLE
PADV-353: Add LTI view permission middleware

### DIFF
--- a/openedx_lti_tool_plugin/middleware.py
+++ b/openedx_lti_tool_plugin/middleware.py
@@ -1,0 +1,66 @@
+"""Middleware for openedx_lti_tool_plugin."""
+import re
+from typing import Any
+
+from django.conf import settings
+from django.contrib.auth import logout
+from django.core.exceptions import MiddlewareNotUsed
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+
+from openedx_lti_tool_plugin.models import LtiProfile
+
+
+class LtiViewPermissionMiddleware:
+    """LTI view permission middleware.
+
+    Attributes:
+        get_response (Any): Callable returned by previous middleware.
+    """
+
+    def __init__(self, get_response: Any):
+        """Middleware initialization.
+
+        Args:
+            get_response: Callable returned by previous middleware.
+
+        Raises:
+            MiddlewareNotUsed if plugin is disabled.
+        """
+        # Disable middleware if plugin is disabled.
+        if not getattr(settings, 'OLTITP_ENABLE_LTI_TOOL', False):
+            raise MiddlewareNotUsed()
+
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """Process request.
+
+        Args:
+            request: HTTP request object.
+
+        Returns:
+            HTTP response object.
+        """
+        return self.get_response(request)
+
+    def process_view(
+        self,
+        request: HttpRequest,
+        *args: tuple,
+    ):
+        """Process request before view call.
+
+        Args:
+            request: HTTP request object.
+            *args: Variable length argument list.
+        """
+        # Allow the view if no LtiProfile is found.
+        # Allow all patterns from OLTITP_URL_WHITELIST setting.
+        if (
+            not LtiProfile.objects.filter(user=request.user.id).exists()
+            or any(re.match(regex, request.path) for regex in settings.OLTITP_URL_WHITELIST)
+        ):
+            return None
+
+        return logout(request)

--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -8,6 +8,8 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 from django.conf import LazySettings
 
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as AppConfig
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'secret-key'
 
@@ -29,6 +31,27 @@ TIME_ZONE = 'UTC'
 USE_TZ = True
 
 
+# Plugin constants.
+BACKENDS_MODULE_PATH = 'openedx_lti_tool_plugin.edxapp_wrapper.backends'
+OLTITP_URL_WHITELIST = [
+    # This app URLs.
+    fr'^/{AppConfig.name}/?.*$',
+    # Favicon icon URL.
+    r'^/favicon.ico$',
+    # Debug URLs.
+    r'^/__debug__/?.*$',
+    # XBlock handler URLs.
+    r'^/courses/.*/xblock/.*/(handler|handler_noauth)/.*/?.*$',
+    # XBlock resource URL.
+    r'^/xblock/resource/?.*$',
+    # Discussion XBlock URLs.
+    r'^/courses/.*/discussion/?.*$',
+    # Tracking event URLs.
+    r'^/segmentio/event/?.*$',
+    r'^/event/?.*$',
+]
+
+
 def plugin_settings(settings: LazySettings):
     """
     Set of plugin settings used by the Open edX platform.
@@ -37,13 +60,14 @@ def plugin_settings(settings: LazySettings):
     https://github.com/openedx/edx-django-utils/tree/master/edx_django_utils/plugins
     """
     settings.OLTITP_ENABLE_LTI_TOOL = False
+    settings.OLTITP_URL_WHITELIST = OLTITP_URL_WHITELIST
     settings.AUTHENTICATION_BACKENDS.append('openedx_lti_tool_plugin.auth.LtiAuthenticationBackend')
+    settings.MIDDLEWARE.append('openedx_lti_tool_plugin.middleware.LtiViewPermissionMiddleware')
 
     # Backends settings
-    backends_module_path = 'openedx_lti_tool_plugin.edxapp_wrapper.backends'
-    settings.OLTITP_COURSE_EXPERIENCES_BACKEND = f'{backends_module_path}.course_experience_module_o_v1'
-    settings.OLTITP_COURSEWARE_BACKEND = f'{backends_module_path}.courseware_module_o_v1'
-    settings.OLTITP_LEARNING_SEQUENCES_BACKEND = f'{backends_module_path}.learning_sequences_module_o_v1'
-    settings.OLTITP_MODULESTORE_BACKEND = f'{backends_module_path}.modulestore_module_o_v1'
-    settings.OLTITP_SAFE_SESSIONS_BACKEND = f'{backends_module_path}.safe_sessions_module_o_v1'
-    settings.OLTITP_STUDENT_BACKEND = f'{backends_module_path}.student_module_o_v1'
+    settings.OLTITP_COURSE_EXPERIENCES_BACKEND = f'{BACKENDS_MODULE_PATH}.course_experience_module_o_v1'
+    settings.OLTITP_COURSEWARE_BACKEND = f'{BACKENDS_MODULE_PATH}.courseware_module_o_v1'
+    settings.OLTITP_LEARNING_SEQUENCES_BACKEND = f'{BACKENDS_MODULE_PATH}.learning_sequences_module_o_v1'
+    settings.OLTITP_MODULESTORE_BACKEND = f'{BACKENDS_MODULE_PATH}.modulestore_module_o_v1'
+    settings.OLTITP_SAFE_SESSIONS_BACKEND = f'{BACKENDS_MODULE_PATH}.safe_sessions_module_o_v1'
+    settings.OLTITP_STUDENT_BACKEND = f'{BACKENDS_MODULE_PATH}.student_module_o_v1'

--- a/openedx_lti_tool_plugin/tests/test_middleware.py
+++ b/openedx_lti_tool_plugin/tests/test_middleware.py
@@ -1,0 +1,103 @@
+"""Tests for the openedx_lti_tool_plugin middleware module."""
+from unittest.mock import MagicMock, patch
+
+from ddt import data, ddt
+from django.core.exceptions import MiddlewareNotUsed
+from django.test import RequestFactory, TestCase, override_settings
+
+from openedx_lti_tool_plugin.middleware import LtiViewPermissionMiddleware
+from openedx_lti_tool_plugin.models import LtiProfile
+
+
+@ddt
+class TestLtiViewPermissionMiddleware(TestCase):
+    """Test LTI view permission middleware."""
+
+    def setUp(self):
+        """Test fixtures setup."""
+        super().setUp()
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
+        self.user = MagicMock(id='random-user-id')
+        self.request.user = self.user
+        self.middleware_class = LtiViewPermissionMiddleware
+
+    @override_settings(OLTITP_ENABLE_LTI_TOOL=False)
+    def test_with_plugin_disabled(self):
+        """Test __init__ method raises MiddlewareNotUsed when plugin is disabled."""
+        with self.assertRaises(MiddlewareNotUsed):
+            self.middleware_class(None)(self.request)
+
+    @data(
+        '/courses/test/xblock/test/handler/test',
+        '/courses/test/xblock/test/handler_noauth/test',
+        '/xblock/resource/test',
+        '/courses/test/discussion/test',
+        '/segmentio/event/test',
+        '/event/test',
+    )
+    @patch('openedx_lti_tool_plugin.middleware.logout')
+    @patch.object(LtiProfile.objects, 'filter')
+    def test_process_view_with_whitelisted_url(
+        self,
+        request_url: str,
+        filter_mock: MagicMock,
+        logout_mock: MagicMock,
+    ):
+        """Test process_view method with whitelisted URL.
+
+        Args:
+            module_path: Fake edx module path.
+            request_url: Request URL string.
+            filter_mock: Mocked LtiProfile.objects filter method.
+            logout_mock: Mocked logout function.
+        """
+        request = self.factory.get(request_url)
+        request.user = self.user
+
+        self.middleware_class(None).process_view(request, None)
+
+        filter_mock.assert_called_once_with(user=self.user.id)
+        filter_mock().exists.assert_called_once_with()
+        logout_mock.assert_not_called()
+
+    @patch('openedx_lti_tool_plugin.middleware.logout')
+    @patch.object(LtiProfile.objects, 'filter')
+    def test_process_view_without_whitelisted_edx_url(
+        self,
+        filter_mock: MagicMock,
+        logout_mock: MagicMock,
+    ):
+        """Test process_view method without whitelisted edx-platform URL.
+
+        Args:
+            module_path: Fake edx module path.
+            filter_mock: Mocked LtiProfile.objects filter method.
+            logout_mock: Mocked logout function.
+        """
+        self.middleware_class(None).process_view(self.request, None)
+
+        filter_mock.assert_called_once_with(user=self.user.id)
+        filter_mock().exists.assert_called_once_with()
+        logout_mock.assert_called_once_with(self.request)
+
+    @patch('openedx_lti_tool_plugin.middleware.logout')
+    @patch.object(LtiProfile.objects, 'filter')
+    def test_process_view_without_lti_profile(
+        self,
+        filter_mock: MagicMock,
+        logout_mock: MagicMock,
+    ):
+        """Test process_view method without LTI profile URL.
+
+        Args:
+            filter_mock: Mocked LtiProfile.objects filter method.
+            logout_mock: Mocked logout function.
+        """
+        filter_mock.return_value.exists.return_value = False
+
+        self.middleware_class(None).process_view(self.request, None)
+
+        filter_mock.assert_called_once_with(user=self.user.id)
+        filter_mock().exists.assert_called_once_with()
+        logout_mock.assert_not_called()


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-353

## Description

This PR adds a LTI view permission middleware, this middleware is in charge of controlling access for LTI users (users with a LTI profile) to views on the platform, this will logout any LTI user trying to access a view other than the views on the LTI plugin, views required by XBlocks on edx-platform and/or third-party packages installed on edx-platform. Third-party packages XBlocks with views that should restricted by LTI users can add new blocklisted URL patterns to the OLTITP_URL_BLOCKLIST setting. Views on the edx-platform that should be whitelisted and are not on the default list can be added to the OLTITP_URL_WHITELIST setting.

## Type of Change

- [x] Add LtiViewPermissionMiddleware middleware class.
- [x] Add OLTITP_URL_BLOCKLIST setting.
- [x] Add OLTITP_URL_WHITELIST setting.
- [x] Add LtiViewPermissionMiddleware to MIDDLEWARE settings.
- [x] Include tests for all added code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should work and you should be able to use all XBlocks without issue.
- Go to any blacklisted URL on edx-platform: http://localhost:18000/contact
- The user should by logout.
- On the launch, any new request should return a 404 response.

## Reviewers

- [x] @Squirrel18 
- [x] @alexjmpb 