### PR TITLE
PADV 363 - Render single unit or component

### DIFF
--- a/openedx_lti_tool_plugin/tests/test_urls.py
+++ b/openedx_lti_tool_plugin/tests/test_urls.py
@@ -29,6 +29,10 @@ class TestUrls(TestCase):
             resolve(reverse('lti1p3-launch', args=[COURSE_ID])).func.view_class,
             LtiToolLaunchView,
         )
+        self.assertEqual(
+            resolve(reverse('lti1p3-launch', args=[COURSE_ID, USAGE_KEY])).func.view_class,
+            LtiToolLaunchView,
+        )
 
     def test_lti_tool_jwks_url_resolves(self):
         """Test LtiToolLoginView URL can be resolved."""

--- a/openedx_lti_tool_plugin/urls.py
+++ b/openedx_lti_tool_plugin/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
             views.LtiToolLaunchView.as_view(),
             name='lti1p3-launch',
         ),
+        re_path(
+            fr'^launch/{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}$',
+            views.LtiToolLaunchView.as_view(),
+            name='lti1p3-launch',
+        ),
     ])),
     re_path(
         fr'^course/{settings.COURSE_ID_PATTERN}/home$',


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-363

## Description

This PR adds the ability to render both an entire course or a single unit or component. The approach taken was to verify the unit exists retrieving it from modulestore, using modulstore().get_item, then verify that the course ID of the object obtained matched the one specified in the launch and lastly verify the usage key is not a chapter nor sequential using the location.block_type attribute of the object. We decided to make it this way because modulestore bring us all the necessary things to do these validation, being this the most efficient way.

## Type of Change

- [x] Modify the Launch view so it can receive the usage key of the component to render
- [x] Add validation to verify if the unit exists, check if the usage key correspond to the course ID and to verify that the block type is not chapter or sequential.

## Screenshots:

### Launch of a single component
![Screenshot from 2023-08-03 12-29-46](https://github.com/Pearson-Advance/openedx-lti-tool-plugin/assets/62396424/c004b128-e242-4cf6-bf9b-308c5598534e)

### Launch of a single unit
![Screenshot from 2023-08-03 12-29-21](https://github.com/Pearson-Advance/openedx-lti-tool-plugin/assets/62396424/ca9c38a6-b6d1-418e-a9ac-b9460029c4e7)

### Launch of the whole course
![Screenshot from 2023-08-03 12-28-26](https://github.com/Pearson-Advance/openedx-lti-tool-plugin/assets/62396424/1d4c0c8c-cff1-439c-bb2a-84503f95b105)

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}/{usage_key}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}/{usage_key}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should work and you should be able to see that the only thing rendered was the desired unit
- Now remove the usage_key from the messageURL and the redirection URIS and try again the launch, you should now see that the whole course was rendered.

## Reviewers

- [ ] @Squirrel18 
- [ ] @kuipumu  