### PR TITLE
PADV-353.1: LTI middleware logging, extra URLs setting

### DIFF
--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -50,6 +50,7 @@ OLTITP_URL_WHITELIST = [
     r'^/segmentio/event/?.*$',
     r'^/event/?.*$',
 ]
+OLTITP_URL_WHITELIST_EXTRA = []
 
 
 def plugin_settings(settings: LazySettings):
@@ -61,6 +62,7 @@ def plugin_settings(settings: LazySettings):
     """
     settings.OLTITP_ENABLE_LTI_TOOL = False
     settings.OLTITP_URL_WHITELIST = OLTITP_URL_WHITELIST
+    settings.OLTITP_URL_WHITELIST_EXTRA = []
     settings.AUTHENTICATION_BACKENDS.append('openedx_lti_tool_plugin.auth.LtiAuthenticationBackend')
     settings.MIDDLEWARE.append('openedx_lti_tool_plugin.middleware.LtiViewPermissionMiddleware')
 


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-353

## Description

This PR improves the already implemented LTI view middleware to ease the debugging of blocked URLs, this PR also includes a new setting OLTITP_URL_WHITELIST_EXTRA that will allow us to extend the whitelisted URLs without replacing the URLs defined in the OLTITP_URL_WHITELIST setting.

## Type of Change

- [x] Add OLTITP_URL_WHITELIST_EXTRA setting.
- [x] Add log call to LtiViewPermissionMiddleware on logout.
- [x] Include tests for all modified code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
# Set extra whitelisted URL.
OLTITP_URL_WHITELIST_EXTRA = ['/extra_path/']
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should work and you should be able to use all XBlocks without issue.
- Go to a URL defined on OLTITP_URL_WHITELIST_EXTRA, you should be able to request it without having the user logout.
- Go to any blacklisted URL on edx-platform: http://localhost:18000/contact
- The user should by logout and a log error with the blocked URL should exist.
- On the launch, any new request should return a 404 response.

## Reviewers

- [x] @Squirrel18 
- [x] @Jacatove 