### PR TITLE
PADV 658 - Filter unavailable units on course outline

### DIFF
--- a/openedx_lti_tool_plugin/edxapp_wrapper/backends/modulestore_module_o_v1.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/backends/modulestore_module_o_v1.py
@@ -1,7 +1,13 @@
 """student module backend (olive v1)."""
+from xmodule.modulestore.django import modulestore  # type: ignore # pylint: disable=import-error
 from xmodule.modulestore.exceptions import ItemNotFoundError  # type: ignore # pylint: disable=import-error
 
 
 def item_not_found_error_backend():
     """Return ItemNotFoundError class."""
     return ItemNotFoundError
+
+
+def modulestore_backend():
+    """Return modulestore function."""
+    return modulestore

--- a/openedx_lti_tool_plugin/edxapp_wrapper/modulestore_module.py
+++ b/openedx_lti_tool_plugin/edxapp_wrapper/modulestore_module.py
@@ -9,3 +9,10 @@ def item_not_found_error():
     return import_module(
         settings.OLTITP_MODULESTORE_BACKEND,
     ).item_not_found_error_backend()
+
+
+def modulestore():
+    """Return modulestore function."""
+    return import_module(
+        settings.OLTITP_MODULESTORE_BACKEND,
+    ).modulestore()

--- a/openedx_lti_tool_plugin/utils.py
+++ b/openedx_lti_tool_plugin/utils.py
@@ -6,6 +6,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from openedx_lti_tool_plugin.edxapp_wrapper.course_experience_module import get_course_outline_block_tree
 from openedx_lti_tool_plugin.edxapp_wrapper.learning_sequences_module import get_user_course_outline
+from openedx_lti_tool_plugin.edxapp_wrapper.modulestore_module import modulestore
 
 
 def get_course_outline(request: HttpRequest, course_id: str) -> dict:
@@ -18,24 +19,37 @@ def get_course_outline(request: HttpRequest, course_id: str) -> dict:
     Returns:
         Dictionary with course outline.
     """
+    course_key = CourseKey.from_string(course_id)
     # Get course block tree for user.
     course_blocks = get_course_outline_block_tree(request, course_id, request.user)
     # Get course outline for user.
     course_outline = get_user_course_outline(
-        CourseKey.from_string(course_id),
+        course_key,
         request.user,
         datetime.now(tz=timezone.utc),
     )
     # Get available sequences in course for user.
-    available_sequences = [str(usage_key) for usage_key in course_outline.sequences]
-    # Remove unavailable sequences from block tree.
+    available_sequences = map(str, course_outline.sequences)
+    available_units = [
+        str(unit.location)
+        for unit in modulestore().get_items(
+            course_key,
+            qualifiers={'block_type': 'vertical'},
+        )
+    ]
+
+    # Remove unavailable sequences/units from block tree.
     for chapter in course_blocks.get('children', []):
-        children = []
-
+        # Replace chapter children with available sequences.
+        chapter['children'] = [
+            sequence for sequence in chapter.get('children', [])
+            if sequence.get('id') in available_sequences
+        ]
         for sequence in chapter.get('children', []):
-            if sequence.get('id') in available_sequences:
-                children.append(sequence)
-
-        chapter['children'] = children
+            # Replace sequence children with published units.
+            sequence['children'] = [
+                unit for unit in sequence.get('children', [])
+                if unit.get('id') in available_units
+            ]
 
     return course_blocks


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-658

## Description

This PR applies a fix to filter out the units that are not yet published. After some discussion on how we are obtaining the outline data, we came to the conclusion of applying this fix to cover this case and make a further work on re-implementing the course outline and navigation functionalities for a LTI launch in such a way that the performance impact is reduced to minimum.

## Type of Change

- [x] Filter out unpublished units from outline

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- On the course you made, create a new unit and do not publish it.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should fail and show a message in the logs.
- Try again but now enabling the waffle switch `openedx_lti_tool_plugin.allow_complete_course_launch`
- The unpublished unit should not show in the outline.

## Reviewers

- [ ] @Squirrel18 
- [ ] @kuipumu 