### PR TITLE
PADV-690: Improve log, response messages

### DIFF
--- a/openedx_lti_tool_plugin/http.py
+++ b/openedx_lti_tool_plugin/http.py
@@ -1,0 +1,23 @@
+"""HTTP objects for openedx_lti_tool_plugin."""
+import logging
+
+from django.http import HttpResponseBadRequest
+
+log = logging.getLogger(__name__)
+
+
+class LoggedHttpResponseBadRequest(HttpResponseBadRequest):
+    """A HTTP 400 response class that sends the response to the log."""
+
+    def __init__(self, message: str, *args, **kwargs):
+        """HTTP response __init__ method.
+
+        Args:
+            message: Error message string.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        super().__init__(message, *args, **kwargs)
+
+        if isinstance(message, str):
+            log.error(message)

--- a/openedx_lti_tool_plugin/middleware.py
+++ b/openedx_lti_tool_plugin/middleware.py
@@ -76,5 +76,9 @@ class LtiViewPermissionMiddleware:
         ):
             return None
 
-        log.error('LTI Middleware: User %s path request blocked: %s', request.user, request.path)
+        log.error(
+            'LTI Middleware: User %s path request blocked: %s',
+            request.user,
+            request.build_absolute_uri(),
+        )
         return logout(request)

--- a/openedx_lti_tool_plugin/models.py
+++ b/openedx_lti_tool_plugin/models.py
@@ -172,7 +172,9 @@ class CourseAccessConfiguration(models.Model):
         """
         try:
             allowed_course_ids = json.loads(self.allowed_course_ids)
-            isinstance(allowed_course_ids, list)
+
+            if not isinstance(allowed_course_ids, list):
+                raise ValueError()
         except ValueError as exc:
             raise ValidationError({
                 'allowed_course_ids': _(f'Should be a list. {self.EXAMPLE_ID_LIST}'),

--- a/openedx_lti_tool_plugin/tests/test_http.py
+++ b/openedx_lti_tool_plugin/tests/test_http.py
@@ -1,0 +1,52 @@
+"""Tests for the openedx_lti_tool_plugin http module."""
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from testfixtures import log_capture
+from testfixtures.logcapture import LogCaptureForDecorator
+
+from openedx_lti_tool_plugin.http import LoggedHttpResponseBadRequest
+
+
+class TestLoggedHttpResponseBadRequest(TestCase):
+    """Test LoggedHttpResponseBadRequest class."""
+
+    @log_capture()
+    @patch('openedx_lti_tool_plugin.http.isinstance', return_value=True)
+    def test_response_with_string_message(
+        self,
+        isinstance_mock: MagicMock,
+        log: LogCaptureForDecorator,
+    ):
+        """Test response with string message argument.
+
+        Args:
+            isinstance_mock: Mocked isinstance function.
+            log: LogCapture fixture.
+        """
+        message = 'random-error'
+        response = LoggedHttpResponseBadRequest(message)
+
+        self.assertEqual(response.content.decode('utf-8'), message)
+        isinstance_mock.assert_called_once_with(message, str)
+        log.check(('openedx_lti_tool_plugin.http', 'ERROR', message))
+
+    @log_capture()
+    @patch('openedx_lti_tool_plugin.http.isinstance', return_value=False)
+    def test_response_without_string_message(
+        self,
+        isinstance_mock: MagicMock,
+        log: LogCaptureForDecorator,
+    ):
+        """Test response without string message argument.
+
+        Args:
+            isinstance_mock: Mocked isinstance function.
+            log: LogCapture fixture.
+        """
+        message = None
+        response = LoggedHttpResponseBadRequest(message)
+
+        self.assertEqual(response.content.decode('utf-8'), str(message))
+        isinstance_mock.assert_called_once_with(message, str)
+        log.check()

--- a/openedx_lti_tool_plugin/tests/test_middleware.py
+++ b/openedx_lti_tool_plugin/tests/test_middleware.py
@@ -106,7 +106,7 @@ class TestLtiViewPermissionMiddleware(TestCase):
             (
                 'openedx_lti_tool_plugin.middleware',
                 'ERROR',
-                f'LTI Middleware: User {self.user} path request blocked: /',
+                f'LTI Middleware: User {self.user} path request blocked: http://testserver/',
             ),
         )
         logout_mock.assert_called_once_with(self.request)

--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -196,12 +196,12 @@ class TestCourseAccessConfiguration(TestCase):
 
     @patch('openedx_lti_tool_plugin.models._', return_value='')
     @patch('openedx_lti_tool_plugin.models.json.loads', side_effect=ValueError())
-    def test_clean_with_invalid_allowed_course_ids(
+    def test_clean_with_invalid_json_allowed_course_ids(
         self,
         json_loads_mock: MagicMock,
         gettext_mock: MagicMock,
     ):
-        """Test clean method with invalid allowed_course_ids field.
+        """Test clean method with invalid JSON on allowed_course_ids field.
 
         Args:
             json_loads_mock: Mocked json.loads function.
@@ -213,6 +213,32 @@ class TestCourseAccessConfiguration(TestCase):
             self.access_configuration.clean()
 
         json_loads_mock.assert_called_once_with('invalid-allowed-course-ids')
+        gettext_mock.assert_called_once_with(f'Should be a list. {self.access_configuration.EXAMPLE_ID_LIST}')
+        self.assertEqual(str(cm.exception), "{'allowed_course_ids': ['']}")
+
+    @patch('openedx_lti_tool_plugin.models._', return_value='')
+    @patch('openedx_lti_tool_plugin.models.isinstance', return_value=False)
+    @patch('openedx_lti_tool_plugin.models.json.loads')
+    def test_clean_with_invalid_instance_allowed_course_ids(
+        self,
+        json_loads_mock: MagicMock,
+        isinstance_mock: MagicMock,
+        gettext_mock: MagicMock,
+    ):
+        """Test clean method with invalid instance on allowed_course_ids field.
+
+        Args:
+            json_loads_mock: Mocked json.loads function.
+            isinstance_mock: Mocked isinstance function.
+            gettext_mock: Mocked gettext function.
+        """
+        self.access_configuration.allowed_course_ids = '{"test": "test"}'
+
+        with self.assertRaises(ValidationError) as cm:
+            self.access_configuration.clean()
+
+        json_loads_mock.assert_called_once_with('{"test": "test"}')
+        isinstance_mock.assert_called_once_with(json_loads_mock(), list)
         gettext_mock.assert_called_once_with(f'Should be a list. {self.access_configuration.EXAMPLE_ID_LIST}')
         self.assertEqual(str(cm.exception), "{'allowed_course_ids': ['']}")
 


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-690

## Description

This PR improves the response handling of LTI views to allow them return clearer messages on errors while also logging the error on the LMS logs for further debugging. This also includes a fix of the allowed_course_ids field on the CourseAccessConfiguration model and also an improvement on the logout log message of the LTI middleware. 

## Type of Change

- [x] Create custom HTTP 400 response class that logs the response content.
- [x] Improve the validation of allowed_course_ids field on the CourseAccessConfiguration model.
- [x] Improve the log message of the LTI middleware logout.
- [x] Add tests for all added and modified code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Run ngrok or any other similar service: `ngrok http 18000`
- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://{ngrok_url}/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://{ngrok_url}/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Click on the "Save" button on the top navbar.
- Modify the LTI tool configuration, LTI launch parameters, Course access configuration allowed course IDs or waffle switches to generate a invalid course response.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe".
- The launch should fail and show a message on the response and in the logs.

## Reviewers

- [ ] @Squirrel18 
- [ ] @alexjmpb  