### PR TITLE
refactor: remove AUTHENTICATION_BACKENDS modification. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,11 +26,12 @@ Installation on Open edX Devstack
   pip install -e /edx/src/openedx-lti-tool-plugin
   /edx/app/edxapp/edx-platform/manage.py lms migrate openedx_lti_tool_plugin # Run plugin migrations
 
-4. Set the lms setting OLTITP_ENABLE_LTI_TOOL to True:
+4. Set the lms setting OLTITP_ENABLE_LTI_TOOL to True and add LtiAuthenticationBackend to AUTHENTICATION_BACKENDS:
 
 .. code-block:: bash
 
   echo 'OLTITP_ENABLE_LTI_TOOL=True' >> ~openedx/edx-platform/lms/envs/devstack_docker.py
+  echo 'AUTHENTICATION_BACKENDS.append('openedx_lti_tool_plugin.auth.LtiAuthenticationBackend')' >> ~openedx/edx-platform/lms/envs/devstack_docker.py
 
 5. Restart the LMS.
 
@@ -92,6 +93,7 @@ LMS Settings
 ============
 
 - `OLTITP_ENABLE_LTI_TOOL`: Enables or disables the LTI tool plugin.
+- `LtiAuthenticationBackend`: Class needed to be added to AUTHENTICATION_BACKENDS.
 
 Django Waffle Switches
 ======================

--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -41,7 +41,6 @@ def plugin_settings(settings: LazySettings):
     https://github.com/openedx/edx-django-utils/tree/master/edx_django_utils/plugins
     """
     settings.OLTITP_ENABLE_LTI_TOOL = False
-    settings.AUTHENTICATION_BACKENDS.append('openedx_lti_tool_plugin.auth.LtiAuthenticationBackend')
 
     # Backends settings
     settings.OLTITP_CORE_SIGNALS_BACKEND = f'{BACKENDS_MODULE_PATH}.core_signals_module_o_v1'


### PR DESCRIPTION
## Description

Once this plugin is installed, it modifies the `AUTHENTICATION_BACKENDS` platform variable. Following the open for extension, but closed for modification principle, this PR stops adding the `LtiAuthenticationBackend` class to `AUTHENTICATION_BACKENDS`, so this setting is handled at configuration settings. The corresponding setting is being added here: https://github.com/Pearson-Advance/tutor-pearson-plugin/pull/98

