### PR TITLE
feat: Improve OLTITP_ENABLE_LTI_TOOL check handling

### DIFF
--- a/openedx_lti_tool_plugin/auth.py
+++ b/openedx_lti_tool_plugin/auth.py
@@ -6,6 +6,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.http.request import HttpRequest
 
 from openedx_lti_tool_plugin.models import LtiProfile, UserT
+from openedx_lti_tool_plugin.utils import is_plugin_enabled
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +38,9 @@ class LtiAuthenticationBackend(ModelBackend):
         Returns:
             LTI profile user instance or None.
         """
+        if not is_plugin_enabled():
+            return None
+
         log.debug('LTI 1.3 authentication: iss=%s, sub=%s, aud=%s', iss, sub, aud)
 
         try:

--- a/openedx_lti_tool_plugin/signals.py
+++ b/openedx_lti_tool_plugin/signals.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
@@ -13,6 +12,7 @@ from openedx_lti_tool_plugin.edxapp_wrapper.core_signals_module import course_gr
 from openedx_lti_tool_plugin.edxapp_wrapper.grades_module import problem_weighted_score_changed
 from openedx_lti_tool_plugin.models import CourseAccessConfiguration, LtiGradedResource, LtiProfile, UserT
 from openedx_lti_tool_plugin.tasks import send_problem_score_update, send_vertical_score_update
+from openedx_lti_tool_plugin.utils import is_plugin_enabled
 
 # There is no constant defined for the max score sent from edx-platform grades signals.
 # We set this constant based on a grade percent that is between 0.0 and 1.0.
@@ -91,7 +91,7 @@ def update_course_score(
     # Ignore signal if plugin is disabled, is not a LTI user grade
     # or the course grade has not been passed.
     if (
-        not getattr(settings, 'OLTITP_ENABLE_LTI_TOOL', False)
+        not is_plugin_enabled()
         or not getattr(user, 'openedx_lti_tool_plugin_lti_profile', None)
         or not course_grade.passed
     ):
@@ -123,7 +123,7 @@ def update_unit_or_problem_score(
         **kwargs: Arbitrary keyword arguments.
     """
     if (
-        not getattr(settings, 'OLTITP_ENABLE_LTI_TOOL', False)
+        not is_plugin_enabled()
         or not LtiProfile.objects.filter(user__id=user_id)
     ):
         return

--- a/openedx_lti_tool_plugin/utils.py
+++ b/openedx_lti_tool_plugin/utils.py
@@ -1,6 +1,17 @@
 """Utilities for openedx_lti_tool_plugin."""
 from typing import Optional
 
+from django.conf import settings
+
+
+def is_plugin_enabled() -> bool:
+    """Check 'OLTITP_ENABLE_LTI_TOOL' setting value.
+
+    Returns:
+        True or False
+    """
+    return getattr(settings, 'OLTITP_ENABLE_LTI_TOOL', False)
+
 
 def get_client_id(aud: list, azp: Optional[str]) -> str:
     """Get client_id from 'aud' claim.

--- a/openedx_lti_tool_plugin/views.py
+++ b/openedx_lti_tool_plugin/views.py
@@ -24,7 +24,7 @@ from openedx_lti_tool_plugin.edxapp_wrapper.user_authn_module import set_logged_
 from openedx_lti_tool_plugin.exceptions import LtiToolLaunchException
 from openedx_lti_tool_plugin.http import LoggedHttpResponseBadRequest
 from openedx_lti_tool_plugin.models import CourseAccessConfiguration, LtiGradedResource, LtiProfile, UserT
-from openedx_lti_tool_plugin.utils import get_client_id, get_pii_from_claims
+from openedx_lti_tool_plugin.utils import get_client_id, get_pii_from_claims, is_plugin_enabled
 from openedx_lti_tool_plugin.waffle import ALLOW_COMPLETE_COURSE_LAUNCH, COURSE_ACCESS_CONFIGURATION, SAVE_PII_DATA
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ def requires_lti_enabled(view_func: _ViewF) -> _ViewF:
         Http404: LTI tool plugin is not enabled.
     """
     def wrapped_view(*args, **kwargs):
-        if not getattr(settings, 'OLTITP_ENABLE_LTI_TOOL', False):
+        if not is_plugin_enabled():
             raise Http404()
 
         return view_func(*args, **kwargs)


### PR DESCRIPTION
## Description

This PR add a new function is_plugin_enabled to improve the OLTITP_ENABLE_LTI_TOOL setting check handling on parts of the plugin that requires to verify if the plugin is enabled or not. This PR also includes an improvement to the LtiAuthenticationBackend to verify if the plugin is enabled before executing any authentication code. Additionally this PR also includes minor improvements to a few plugin unit tests.

## Type of Change

- [x] Add is_plugin_enabled function.
- [x] Replace all existing verification of OLTITP_ENABLE_LTI_TOOL setting with is_plugin_enabled function.
- [x] Add tests for all added and modified code.
- [x] Minor improvements to existing tests.

## Testing:

- Setup the plugin: https://github.com/Pearson-Advance/openedx-lti-tool-plugin#installation-on-open-edx-devstack
- Setup a resource launch on a LTI platform: https://github.com/Pearson-Advance/openedx-lti-tool-plugin#lti-13-resource-launch-setup
- Set OLTITP_ENABLE_LTI_TOOL setting to True.
- Execute the LTI launch.
- The LTI launch should work and authenticate the user.
- Set OLTITP_ENABLE_LTI_TOOL setting to False.
- Execute the LTI launch.
- The LTI launch should fail to authenticate the user.	

## Reviewers

- [x] @alexjmpb  
- [x] @Squirrel18