### PR TITLE
PADV-1128: Improve AGS callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ requirements: ## install core requirements
 dev-requirements: requirements ## install development requirements and Django
 	pip install -r requirements/test.txt
 
-quality: clean ## check coding style
+quality: ## check coding style
 	$(TOX) pylint ${APP_MODULE} manage.py setup.py
 	$(TOX) pycodestyle ${APP_MODULE} manage.py setup.py
 	$(TOX) pydocstyle ${APP_MODULE} manage.py setup.py
 	$(TOX) isort --check-only --diff ${APP_MODULE} manage.py setup.py
 
-test: clean ## run tests
+test: ## run tests
 	$(TOX) python manage.py check
 	$(TOX) pytest
 

--- a/openedx_lti_tool_plugin/signals.py
+++ b/openedx_lti_tool_plugin/signals.py
@@ -88,12 +88,12 @@ def update_course_score(
         course_key: Course opaque key.
         **kwargs: Arbitrary keyword arguments.
     """
-    # Ignore signal if plugin is disabled, is not a LTI user grade
-    # or the course grade has not been passed.
+    # Ignore the signal if the plugin is disabled, the grade is not
+    # of an LTI profile or the course grade percent is less than 0.0.
     if (
         not is_plugin_enabled()
         or not getattr(user, 'openedx_lti_tool_plugin_lti_profile', None)
-        or not course_grade.passed
+        or (getattr(course_grade, 'percent', None) or -0.1) < 0.0
     ):
         return
 


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1128

## Description

This PR adds improvements to the AGS callback on course launches, this PR removes the limit of AGS score update callbacks by allowing score updates on any course grade that has any percent value, additionally this PR removes the call for the clean command on the quality and test Makefile command, this command was uninstalling the plugin from the development environment thus making harder debugging after local CI tests.

## Type of Change

- Modify update_course_score function on signals.py module.
- Remove clean command from quality and test Makefile commands.
- Add or modify any unit test for all related code.

## Reviewers

- [ ] @Squirrel18 
- [ ] @alexjmpb 
 