### PR TITLE
PADV-1190: Add Deep Linking views.

### DIFF
--- a/openedx_lti_tool_plugin/deep_linking/__init__.py
+++ b/openedx_lti_tool_plugin/deep_linking/__init__.py
@@ -1,0 +1,1 @@
+"""LTI Deep Linking."""

--- a/openedx_lti_tool_plugin/deep_linking/exceptions.py
+++ b/openedx_lti_tool_plugin/deep_linking/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions."""
+
+
+class DeepLinkingException(Exception):
+    """A exception for Deep Linking errors."""

--- a/openedx_lti_tool_plugin/deep_linking/tests/__init__.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Test deep_linking module."""
+
+MODULE_PATH = 'openedx_lti_tool_plugin.deep_linking'

--- a/openedx_lti_tool_plugin/deep_linking/tests/test_urls.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/test_urls.py
@@ -1,0 +1,36 @@
+"""Test urls module."""
+from uuid import uuid4
+
+from django.test import TestCase
+from django.urls import resolve, reverse
+
+from openedx_lti_tool_plugin.deep_linking.views import DeepLinkingFormView, DeepLinkingView
+
+
+class TestDeepLinkingViewUrlPatterns(TestCase):
+    """Test DeepLinkingView Django URL configuration."""
+
+    def test_view_url(self):
+        """Test view URL."""
+        self.assertEqual(
+            resolve(
+                reverse('1.3:deep-linking:root'),
+            ).func.view_class,
+            DeepLinkingView,
+        )
+
+
+class TestDeepLinkingFormViewUrlPatterns(TestCase):
+    """Test DeepLinkingFormView Django URL configuration."""
+
+    def test_view_url(self):
+        """Test view URL."""
+        self.assertEqual(
+            resolve(
+                reverse(
+                    '1.3:deep-linking:form',
+                    kwargs={'launch_id': uuid4()},
+                ),
+            ).func.view_class,
+            DeepLinkingFormView,
+        )

--- a/openedx_lti_tool_plugin/deep_linking/tests/test_views.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/test_views.py
@@ -1,0 +1,310 @@
+"""Tests views module."""
+from unittest.mock import MagicMock, PropertyMock, patch
+from uuid import uuid4
+
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from pylti1p3.exception import LtiException
+
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
+from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
+from openedx_lti_tool_plugin.deep_linking.tests import MODULE_PATH
+from openedx_lti_tool_plugin.deep_linking.views import (
+    DeepLinkingFormView,
+    DeepLinkingView,
+    validate_deep_linking_message,
+)
+
+MODULE_PATH = f'{MODULE_PATH}.views'
+
+
+class TestValidateDeepLinkingMessage(TestCase):
+    """Test validate_deep_linking_message function."""
+
+    def test_validate_deep_linking_message(self: MagicMock):
+        """Test with LtiDeepLinkingRequest message."""
+        message = MagicMock()
+        message.is_deep_link_launch.return_value = True
+
+        validate_deep_linking_message(message)
+
+        message.is_deep_link_launch.assert_called_once_with()
+
+    @patch(f'{MODULE_PATH}._', return_value='')
+    def test_without_deep_linking_request_message(
+        self: MagicMock,
+        gettext_mock: MagicMock,
+    ):
+        """Test without LtiDeepLinkingRequest message."""
+        message = MagicMock()
+        message.is_deep_link_launch.return_value = False
+
+        with self.assertRaises(DeepLinkingException) as ctxm:
+            validate_deep_linking_message(message)
+
+        message.is_deep_link_launch.assert_called_once_with()
+        gettext_mock.assert_called_once_with('Message type is not LtiDeepLinkingRequest.')
+        self.assertEqual(gettext_mock(), str(ctxm.exception))
+
+
+@patch.object(DeepLinkingView, 'tool_config', new_callable=PropertyMock)
+@patch.object(DeepLinkingView, 'tool_storage', new_callable=PropertyMock)
+@patch(f'{MODULE_PATH}.DjangoMessageLaunch')
+@patch(f'{MODULE_PATH}.validate_deep_linking_message')
+@patch(f'{MODULE_PATH}.redirect')
+class TestDeepLinkingViewPost(TestCase):
+    """Test ResourceLinkLaunchView post method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.view_class = DeepLinkingView
+        self.factory = RequestFactory()
+        self.url = reverse('1.3:deep-linking:root')
+        self.request = self.factory.post(self.url)
+
+    def test_post(
+        self,
+        redirect_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        message_launch_mock: MagicMock,
+        tool_storage_mock: MagicMock,
+        tool_conf_mock: MagicMock,
+    ):
+        """Test `post` method with LtiDeepLinkingRequest (happy path)."""
+        self.assertEqual(
+            self.view_class.as_view()(self.request),
+            redirect_mock.return_value,
+        )
+        message_launch_mock.assert_called_once_with(
+            self.request,
+            tool_conf_mock(),
+            launch_data_storage=tool_storage_mock(),
+        )
+        validate_deep_linking_message_mock.assert_called_once_with(message_launch_mock())
+        message_launch_mock().get_launch_id.assert_called_once_with()
+        message_launch_mock().get_launch_id().replace.assert_called_once_with('lti1p3-launch-', '')
+        redirect_mock.assert_called_once_with(
+            f'{app_config.name}:1.3:deep-linking:form',
+            launch_id=message_launch_mock().get_launch_id().replace(),
+        )
+
+    @patch.object(DeepLinkingView, 'http_response_error')
+    def test_raises_lti_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        redirect_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        message_launch_mock: MagicMock,
+        tool_storage_mock: MagicMock,
+        tool_conf_mock: MagicMock,
+    ):
+        """Test raises LtiException."""
+        exception = LtiException('Error message')
+        message_launch_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request),
+            http_response_error_mock.return_value,
+        )
+        message_launch_mock.assert_called_once_with(
+            self.request,
+            tool_conf_mock(),
+            launch_data_storage=tool_storage_mock(),
+        )
+        validate_deep_linking_message_mock.assert_not_called()
+        redirect_mock.assert_not_called()
+        http_response_error_mock.assert_called_once_with(exception)
+
+    @patch.object(DeepLinkingView, 'http_response_error')
+    def test_raises_deep_linking_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        redirect_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        message_launch_mock: MagicMock,
+        tool_storage_mock: MagicMock,
+        tool_conf_mock: MagicMock,
+    ):
+        """Test raises DeepLinkingException."""
+        exception = DeepLinkingException('Error message')
+        validate_deep_linking_message_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request),
+            http_response_error_mock.return_value,
+        )
+        message_launch_mock.assert_called_once_with(
+            self.request,
+            tool_conf_mock(),
+            launch_data_storage=tool_storage_mock(),
+        )
+        validate_deep_linking_message_mock.assert_called_once_with(message_launch_mock())
+        redirect_mock.assert_not_called()
+        http_response_error_mock.assert_called_once_with(exception)
+
+
+@patch.object(DeepLinkingFormView, 'get_message_from_cache')
+@patch(f'{MODULE_PATH}.validate_deep_linking_message')
+class TestDeepLinkingFormViewGet(TestCase):
+    """Test DeepLinkingFormView get method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.view_class = DeepLinkingFormView
+        self.factory = RequestFactory()
+        self.launch_id = uuid4()
+        self.url = reverse('1.3:deep-linking:form', args=[self.launch_id])
+        self.request = self.factory.get(self.url)
+
+    @patch(f'{MODULE_PATH}.HttpResponse')
+    def test_get(
+        self,
+        http_response_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test `get` method with valid launch_id (happy path)."""
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_called_once_with(get_message_from_cache_mock())
+        http_response_mock.assert_called_once_with()
+
+    @patch.object(DeepLinkingFormView, 'http_response_error')
+    def test_raises_lti_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test raises LtiException."""
+        exception = LtiException('Error message')
+        get_message_from_cache_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_error_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_not_called()
+        http_response_error_mock.assert_called_once_with(exception)
+
+    @patch.object(DeepLinkingFormView, 'http_response_error')
+    def test_raises_deep_linking_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test raises DeepLinkingException."""
+        exception = DeepLinkingException('Error message')
+        validate_deep_linking_message_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_error_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_called_once_with(get_message_from_cache_mock())
+        http_response_error_mock.assert_called_once_with(exception)
+
+
+@patch.object(DeepLinkingFormView, 'get_message_from_cache')
+@patch(f'{MODULE_PATH}.validate_deep_linking_message')
+class TestDeepLinkingFormViewPost(TestCase):
+    """Test DeepLinkingFormView post method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.view_class = DeepLinkingFormView
+        self.factory = RequestFactory()
+        self.launch_id = uuid4()
+        self.url = reverse('1.3:deep-linking:form', args=[self.launch_id])
+        self.request = self.factory.post(self.url)
+
+    @patch(f'{MODULE_PATH}.HttpResponse')
+    def test_post(
+        self,
+        http_response_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test `post` method with valid launch_id (happy path)."""
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_called_once_with(get_message_from_cache_mock())
+        http_response_mock.assert_called_once_with()
+
+    @patch.object(DeepLinkingFormView, 'http_response_error')
+    def test_raises_lti_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test raises LtiException."""
+        exception = LtiException('Error message')
+        get_message_from_cache_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_error_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_not_called()
+        http_response_error_mock.assert_called_once_with(exception)
+
+    @patch.object(DeepLinkingFormView, 'http_response_error')
+    def test_raises_deep_linking_exception(
+        self,
+        http_response_error_mock: MagicMock,
+        validate_deep_linking_message_mock: MagicMock,
+        get_message_from_cache_mock: MagicMock,
+    ):
+        """Test raises DeepLinkingException."""
+        exception = DeepLinkingException('Error message')
+        validate_deep_linking_message_mock.side_effect = exception
+
+        self.assertEqual(
+            self.view_class.as_view()(self.request, self.launch_id),
+            http_response_error_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(self.request, self.launch_id)
+        validate_deep_linking_message_mock.assert_called_once_with(get_message_from_cache_mock())
+        http_response_error_mock.assert_called_once_with(exception)
+
+
+@patch.object(DeepLinkingFormView, 'tool_config', new_callable=PropertyMock)
+@patch.object(DeepLinkingFormView, 'tool_storage', new_callable=PropertyMock)
+@patch(f'{MODULE_PATH}.DjangoMessageLaunch')
+class TestDeepLinkingFormViewGetMessageFromCache(TestCase):
+    """Test DeepLinkingFormView get_message_from_cache method."""
+
+    def test_get_message_from_cache(
+        self,
+        message_launch_mock: MagicMock,
+        tool_storage_mock: MagicMock,
+        tool_conf_mock: MagicMock,
+    ):
+        """Test `get_message_from_cache` method with valid launch_id (happy path)."""
+        request = MagicMock()
+        launch_id = uuid4()
+
+        self.assertEqual(
+            DeepLinkingFormView().get_message_from_cache(request, launch_id),
+            message_launch_mock.from_cache.return_value,
+        )
+        message_launch_mock.from_cache.assert_called_once_with(
+            f'lti1p3-launch-{launch_id}',
+            request,
+            tool_conf_mock(),
+            launch_data_storage=tool_storage_mock(),
+        )

--- a/openedx_lti_tool_plugin/deep_linking/urls.py
+++ b/openedx_lti_tool_plugin/deep_linking/urls.py
@@ -1,0 +1,24 @@
+"""Django URL Configuration.
+
+Attributes:
+    app_name (str): URL pattern namespace.
+    urlpatterns (list): URL patterns list.
+
+"""
+from django.urls import path
+
+from openedx_lti_tool_plugin.deep_linking import views
+
+app_name = 'deep-linking'
+urlpatterns = [
+    path(
+        '',
+        views.DeepLinkingView.as_view(),
+        name='root',
+    ),
+    path(
+        '<uuid:launch_id>',
+        views.DeepLinkingFormView.as_view(),
+        name='form',
+    ),
+]

--- a/openedx_lti_tool_plugin/deep_linking/views.py
+++ b/openedx_lti_tool_plugin/deep_linking/views.py
@@ -1,0 +1,180 @@
+"""Django Views."""
+from typing import Union
+from uuid import uuid4
+
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext as _
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.csrf import csrf_exempt
+from pylti1p3.contrib.django import DjangoMessageLaunch
+from pylti1p3.exception import LtiException
+
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
+from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
+from openedx_lti_tool_plugin.http import LoggedHttpResponseBadRequest
+from openedx_lti_tool_plugin.views import LtiToolBaseView
+
+
+def validate_deep_linking_message(message: DjangoMessageLaunch):
+    """
+    Validate DjangoMessageLaunch type is LtiDeepLinkingRequest.
+
+    Args:
+        message: DjangoMessageLaunch object.
+
+    Raises:
+        DeepLinkingException: If message type is not LtiDeepLinkingRequest.
+
+    .. _LTI 1.3 Advantage Tool implementation in Python - LTI Message Launches:
+        https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
+
+    """
+    if not message.is_deep_link_launch():
+        raise DeepLinkingException(
+            _('Message type is not LtiDeepLinkingRequest.'),
+        )
+
+
+@method_decorator([csrf_exempt, xframe_options_exempt], name='dispatch')
+class DeepLinkingView(LtiToolBaseView):
+    """Deep Linking View.
+
+    This view handles the initial LtiDeepLinkingRequest from the platform.
+
+    .. _LTI Deep Linking Specification - Workflow:
+        https://www.imsglobal.org/spec/lti-dl/v2p0#workflow
+
+    .. _LTI 1.3 Advantage Tool implementation in Python - LTI Message Launches:
+        https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
+
+    """
+
+    def post(
+        self,
+        request: HttpRequest,
+    ) -> Union[HttpResponse, LoggedHttpResponseBadRequest]:
+        """HTTP POST request method.
+
+        Validate LtiDeepLinkingRequest message and redirect to DeepLinkingFormView.
+
+        Args:
+            request: HttpRequest object.
+
+        Returns:
+            HttpResponse or LoggedHttpResponseBadRequest.
+
+        """
+        try:
+            message = DjangoMessageLaunch(
+                request,
+                self.tool_config,
+                launch_data_storage=self.tool_storage,
+            )
+            validate_deep_linking_message(message)
+
+            return redirect(
+                f'{app_config.name}:1.3:deep-linking:form',
+                launch_id=message.get_launch_id().replace('lti1p3-launch-', ''),
+            )
+        except (LtiException, DeepLinkingException) as exc:
+            return self.http_response_error(exc)
+
+
+class DeepLinkingFormView(LtiToolBaseView):
+    """Deep Linking Form View.
+
+    This view renders an interface allowing the user to discover and select one
+    or more specific items to integrate back into the platform and also redirect
+    the user's browser back to the platform along with details of the item(s) selected.
+
+    .. _LTI Deep Linking Specification - Workflow:
+        https://www.imsglobal.org/spec/lti-dl/v2p0#workflow
+
+    .. _LTI 1.3 Advantage Tool implementation in Python - LTI Message Launches:
+        https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
+
+    """
+
+    def get(
+        self,
+        request: HttpRequest,
+        launch_id: uuid4,
+    ) -> Union[HttpResponse, LoggedHttpResponseBadRequest]:
+        """HTTP GET request method.
+
+        Validate cached LtiDeepLinkingRequest message and render DeepLinkingForm.
+
+        Args:
+            request: HttpRequest object.
+            launch_id: Launch ID UUID4.
+
+        Returns:
+            HttpResponse or LoggedHttpResponseBadRequest.
+
+        """
+        try:
+            message = self.get_message_from_cache(request, launch_id)
+            validate_deep_linking_message(message)
+
+            # TODO: Add template response with form to allow user to select
+            # the resource links they want and the launch message launch_id.
+            return HttpResponse()
+        except (LtiException, DeepLinkingException) as exc:
+            return self.http_response_error(exc)
+
+    def post(
+        self,
+        request: HttpRequest,
+        launch_id: uuid4,
+    ) -> Union[HttpResponse, LoggedHttpResponseBadRequest]:
+        """HTTP POST request method.
+
+        Validate cached LtiDeepLinkingRequest message, DeepLinkingForm
+        and render Deep Linking Response with selected form items.
+
+        Args:
+            request: HttpRequest object.
+            launch_id: Launch ID UUID4.
+
+        Returns:
+            HttpResponse or LoggedHttpResponseBadRequest.
+
+        """
+        try:
+            message = self.get_message_from_cache(request, launch_id)
+            validate_deep_linking_message(message)
+
+            # TODO: Add code to obtain form and validate form with resource link data and
+            # add code to process form cleaned data and generate the Deep Linking response:
+            # https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#deep-linking-responses
+            return HttpResponse()
+        except (LtiException, DeepLinkingException) as exc:
+            return self.http_response_error(exc)
+
+    def get_message_from_cache(
+        self,
+        request: HttpRequest,
+        launch_id: uuid4,
+    ) -> DjangoMessageLaunch:
+        """Get DjangoMessageLaunch from Django cache storage.
+
+        Args:
+            request: HttpRequest object.
+            launch_id: Launch ID UUID4.
+
+        Returns:
+            DjangoMessageLaunch object.
+
+        .. _LTI 1.3 Advantage Tool implementation in Python - Accessing Cached Launch Requests:
+            https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#accessing-cached-launch-requests
+
+        """
+        return DjangoMessageLaunch.from_cache(
+            f'lti1p3-launch-{launch_id}',
+            request,
+            self.tool_config,
+            launch_data_storage=self.tool_storage,
+        )

--- a/openedx_lti_tool_plugin/urls.py
+++ b/openedx_lti_tool_plugin/urls.py
@@ -7,6 +7,7 @@ lti_1p3_urls = [
     path('login', views.LtiToolLoginView.as_view(), name='login'),
     path('pub/jwks', views.LtiToolJwksView.as_view(), name='jwks'),
     path('launch/', include('openedx_lti_tool_plugin.resource_link_launch.urls')),
+    path('deep_linking/', include('openedx_lti_tool_plugin.deep_linking.urls')),
 ]
 urlpatterns = [
     path('1.3/', include((lti_1p3_urls, '1.3'))),

--- a/openedx_lti_tool_plugin/views.py
+++ b/openedx_lti_tool_plugin/views.py
@@ -43,7 +43,16 @@ class LtiBaseView(View):
 
 
 class LtiToolBaseView(LtiBaseView):
-    """Base LTI view initializing common LTI tool attributes."""
+    """Base LTI view initializing common LTI tool attributes.
+
+    Attributes:
+        tool_config (DjangoDbToolConf): pylti1.3 Tool Configuration.
+        tool_storage (DjangoCacheDataStorage): pylti1.3 Cache Storage.
+
+    .. _LTI 1.3 Advantage Tool implementation in Python - LTI Message Launches:
+        https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
+
+    """
 
     tool_config = None
     tool_storage = None
@@ -55,10 +64,27 @@ class LtiToolBaseView(LtiBaseView):
             request: HTTP request object.
             *args: Variable length argument list.
             **kwargs: Arbitrary keyword arguments.
+
         """
         super().setup(request, *args, **kwargs)
         self.tool_config = DjangoDbToolConf()
         self.tool_storage = DjangoCacheDataStorage(cache_name='default')
+
+    def http_response_error(self, message: Union[str, Exception]) -> LoggedHttpResponseBadRequest:
+        """HTTP response with an error message.
+
+        This method will create a HTTP response error with an error message
+        prefixed with the LTI specification version and the view name of the error.
+
+        Args:
+            message: Error message string or Exception object.
+
+        Returns:
+            LoggedHttpResponseBadRequest object with error message
+                prefixed with LTI version and view name.
+
+        """
+        return LoggedHttpResponseBadRequest(f'LTI 1.3 {self.__class__.__name__}: {message}')
 
 
 @method_decorator(csrf_exempt, name='dispatch')


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1190

## Description

This PR adds the views for the Deep Linking feature, currently the view can be interacted with a Deep Linking request but there is still some development pending to be done on these views that will be addressed on PADV-1191 that will allow to use the views on a complete Deep Linking UI workflow. 

## Type of Change

- [x] Add `deep_linking` module.
- [x] Add `DeepLinkingView` class.
- [x] Add `DeepLinkingFormView` class.
- [x] Add `http_response_error` method to `LtiToolBaseView` view.
- [x] Add or modify all tests related to this code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Run ngrok or any other similar service on LMS: `ngrok http 18000`
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Go to "Message" on the left sidebar and set these settings:

```
Message type: LtiDeepLinkingRequest
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe" or "Open in new window".
- The request should take you to the DeepLinkingFormView GET response after being redirected from the DeepLinkingView POST action.

## Reviewers

- [x] @alexjmpb  
- [x] @anfbermudezme 
