### PR TITLE
PADV-1201: Filter courses in DeepLinkingForm

### DIFF
--- a/openedx_lti_tool_plugin/deep_linking/forms.py
+++ b/openedx_lti_tool_plugin/deep_linking/forms.py
@@ -1,59 +1,71 @@
 """Django Forms."""
-from typing import List, Optional, Set, Tuple
+import json
+from typing import Optional, Set, Tuple
 
 from django import forms
 from django.http.request import HttpRequest
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool
 from pylti1p3.deep_link_resource import DeepLinkResource
 
 from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
+from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
 from openedx_lti_tool_plugin.edxapp_wrapper.learning_sequences import course_context
+from openedx_lti_tool_plugin.models import CourseAccessConfiguration
+from openedx_lti_tool_plugin.waffle import COURSE_ACCESS_CONFIGURATION
 
 
 class DeepLinkingForm(forms.Form):
     """Deep Linking Form."""
 
-    def __init__(self, *args: tuple, request=None, **kwargs: dict):
+    content_items = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        label=_('Courses'),
+    )
+
+    def __init__(
+        self,
+        *args: tuple,
+        request: HttpRequest,
+        lti_tool: LtiTool,
+        **kwargs: dict,
+    ):
         """Class __init__ method.
 
-        Initialize class instance attributes and add `content_items` field.
+        Initialize class instance attributes and add field choices
+        to the `content_items` field.
 
         Args:
             *args: Variable length argument list.
             request: HttpRequest object.
+            lti_tool: LtiTool model instance.
             **kwargs: Arbitrary keyword arguments.
 
         """
         super().__init__(*args, **kwargs)
-        self.fields['content_items'] = forms.MultipleChoiceField(
-            choices=self.get_content_items_choices(request),
-            required=False,
-            widget=forms.CheckboxSelectMultiple,
-            label=_('Courses'),
-        )
+        self.request = request
+        self.lti_tool = lti_tool
+        self.fields['content_items'].choices = self.get_content_items_choices()
 
-    def get_content_items_choices(self, request: HttpRequest) -> List[Tuple[str, str]]:
+    def get_content_items_choices(self) -> Set[Optional[Tuple[str, str]]]:
         """Get `content_items` field choices.
 
-        Args:
-            request: HttpRequest object.
-
         Returns:
-            List of tuples with choices for the `content_items` field.
+            Set of tuples with choices for the `content_items` field or an empty set.
 
         """
-        return [
-            self.get_content_items_choice(course, request)
-            for course in course_context().objects.all()
-        ]
+        return {
+            self.get_content_items_choice(course)
+            for course in self.get_course_contexts()
+        }
 
-    def get_content_items_choice(self, course, request: HttpRequest) -> Tuple[str, str]:
+    def get_content_items_choice(self, course) -> Tuple[str, str]:
         """Get `content_items` field choice.
 
         Args:
             course (CourseContext): Course object.
-            request: HttpRequest object.
 
         Returns:
             Tuple containing the choice value and name.
@@ -68,8 +80,39 @@ class DeepLinkingForm(forms.Form):
         )
 
         return (
-            request.build_absolute_uri(relative_url),
+            self.request.build_absolute_uri(relative_url),
             course.learning_context.title,
+        )
+
+    def get_course_contexts(self):
+        """Get CourseContext objects.
+
+        Returns:self.cleaned_data
+            All CourseContext objects if COURSE_ACCESS_CONFIGURATION switch
+            is disabled or all CourseContext objects matching the IDs in
+            the CourseAccessConfiguration `allowed_course_ids` field.
+
+        Raises:
+            CourseAccessConfiguration.DoesNotExist: If CourseAccessConfiguration
+            does not exist for this form `lti_tool` attribute.
+
+        """
+        if not COURSE_ACCESS_CONFIGURATION.is_enabled():
+            return course_context().objects.all()
+
+        try:
+            course_access_config = CourseAccessConfiguration.objects.get(
+                lti_tool=self.lti_tool,
+            )
+        except CourseAccessConfiguration.DoesNotExist as exc:
+            raise DeepLinkingException(
+                _(f'Course access configuration not found: {self.lti_tool.title}.'),
+            ) from exc
+
+        return course_context().objects.filter(
+            learning_context__context_key__in=json.loads(
+                course_access_config.allowed_course_ids,
+            ),
         )
 
     def get_deep_link_resources(self) -> Set[Optional[DeepLinkResource]]:

--- a/openedx_lti_tool_plugin/deep_linking/tests/test_forms.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/test_forms.py
@@ -1,80 +1,87 @@
 """Tests forms module."""
 from unittest.mock import MagicMock, patch
 
-from django import forms
 from django.test import TestCase
 
 from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
+from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
 from openedx_lti_tool_plugin.deep_linking.forms import DeepLinkingForm
 from openedx_lti_tool_plugin.deep_linking.tests import MODULE_PATH
+from openedx_lti_tool_plugin.models import CourseAccessConfiguration
 
 MODULE_PATH = f'{MODULE_PATH}.forms'
 
 
-class TestDeepLinkingForm(TestCase):
-    """Test DeepLinkingForm class."""
+class DeepLinkingFormBaseTestCase(TestCase):
+    """DeepLinkingForm TestCase."""
 
     def setUp(self):
         """Set up test fixtures."""
         super().setUp()
         self.form_class = DeepLinkingForm
         self.request = MagicMock()
+        self.lti_tool = MagicMock()
+        self.form_kwargs = {'request': self.request, 'lti_tool': self.lti_tool}
         self.learning_context = MagicMock(context_key='random-course-key', title='Test')
         self.course = MagicMock(learning_context=self.learning_context)
 
-    @patch(f'{MODULE_PATH}.forms.MultipleChoiceField')
-    @patch(f'{MODULE_PATH}._')
-    @patch.object(DeepLinkingForm, 'get_content_items_choices')
+
+@patch.object(DeepLinkingForm, 'get_content_items_choices', return_value=[])
+class TestDeepLinkingFormInit(DeepLinkingFormBaseTestCase):
+    """Test DeepLinkingForm `__init__` method."""
+
     def test_init(
         self,
         get_content_items_choices_mock: MagicMock,
-        gettext_mock: MagicMock,
-        multiple_choice_field_mock: MagicMock,
     ):
         """Test `__init__` method."""
-        self.assertEqual(
-            self.form_class(request=self.request).fields,
-            {'content_items': multiple_choice_field_mock.return_value},
-        )
-        get_content_items_choices_mock.assert_called_once_with(self.request)
-        gettext_mock.assert_called_once_with('Courses')
-        multiple_choice_field_mock.assert_called_once_with(
-            choices=get_content_items_choices_mock(),
-            required=False,
-            widget=forms.CheckboxSelectMultiple,
-            label=gettext_mock(),
-        )
+        form = self.form_class(request=self.request, lti_tool=self.lti_tool)
 
-    @patch(f'{MODULE_PATH}.course_context')
-    @patch.object(DeepLinkingForm, 'get_content_items_choice')
-    @patch.object(DeepLinkingForm, '__init__', return_value=None)
+        self.assertEqual(form.request, self.request)
+        self.assertEqual(form.lti_tool, self.lti_tool)
+        self.assertEqual(
+            list(form.fields['content_items'].choices),
+            get_content_items_choices_mock.return_value,
+        )
+        get_content_items_choices_mock.assert_called_once_with()
+
+
+@patch.object(DeepLinkingForm, 'get_course_contexts')
+@patch.object(DeepLinkingForm, 'get_content_items_choice')
+@patch.object(DeepLinkingForm, '__init__', return_value=None)
+class TestDeepLinkingFormGetContentItemsChoices(DeepLinkingFormBaseTestCase):
+    """Test DeepLinkingForm `get_content_items_choices` method."""
+
     def test_get_content_items_choices(
         self,
-        deep_linking_form_init: MagicMock,  # pylint: disable=unused-argument
+        init_mock: MagicMock,  # pylint: disable=unused-argument
         get_content_items_choice_mock: MagicMock,
-        course_context_mock: MagicMock,
+        get_course_contexts_mock: MagicMock,
     ):
         """Test `get_content_items_choices` method."""
-        course_context_mock.return_value.objects.all.return_value = [self.course]
+        get_course_contexts_mock.return_value = [self.course]
 
         self.assertEqual(
-            self.form_class().get_content_items_choices(self.request),
-            [get_content_items_choice_mock.return_value],
+            self.form_class(**self.form_kwargs).get_content_items_choices(),
+            {get_content_items_choice_mock.return_value},
         )
-        course_context_mock.assert_called_once_with()
-        course_context_mock().objects.all.assert_called_once_with()
-        get_content_items_choice_mock.assert_called_once_with(self.course, self.request)
+        get_course_contexts_mock.assert_called_once_with()
+        get_content_items_choice_mock.assert_called_once_with(self.course)
 
-    @patch(f'{MODULE_PATH}.reverse')
-    @patch.object(DeepLinkingForm, '__init__', return_value=None)
+
+@patch(f'{MODULE_PATH}.reverse')
+@patch.object(DeepLinkingForm, 'get_content_items_choices')
+class TestDeepLinkingFormGetContentItemsChoice(DeepLinkingFormBaseTestCase):
+    """Test DeepLinkingForm `get_content_items_choice` method."""
+
     def test_get_content_items_choice(
         self,
-        deep_linking_form_init: MagicMock,  # pylint: disable=unused-argument
+        get_content_items_choices_mock: MagicMock,  # pylint: disable=unused-argument
         reverse_mock: MagicMock,
     ):
         """Test `get_content_items_choice` method."""
         self.assertEqual(
-            self.form_class().get_content_items_choice(self.course, self.request),
+            self.form_class(**self.form_kwargs).get_content_items_choice(self.course),
             (
                 self.request.build_absolute_uri.return_value,
                 self.course.learning_context.title,
@@ -86,16 +93,101 @@ class TestDeepLinkingForm(TestCase):
         )
         self.request.build_absolute_uri.assert_called_once_with(reverse_mock())
 
-    @patch(f'{MODULE_PATH}.DeepLinkResource')
-    @patch.object(DeepLinkingForm, '__init__', return_value=None)
+
+@patch(f'{MODULE_PATH}.course_context')
+@patch(f'{MODULE_PATH}.json.loads')
+@patch.object(CourseAccessConfiguration.objects, 'get')
+@patch(f'{MODULE_PATH}.COURSE_ACCESS_CONFIGURATION')
+@patch.object(DeepLinkingForm, 'get_content_items_choices')
+class TestDeepLinkingFormGetCourseContexts(DeepLinkingFormBaseTestCase):
+    """Test DeepLinkingForm `get_course_contexts` method."""
+
+    def test_get_course_contexts(
+        self,
+        get_content_items_choices_mock: MagicMock,  # pylint: disable=unused-argument
+        course_access_configuration_switch_mock: MagicMock,
+        course_access_configuration_get_mock: MagicMock,
+        json_loads_mock: MagicMock,
+        course_context: MagicMock,
+    ):
+        """Test `get_course_contexts` method."""
+        self.assertEqual(
+            self.form_class(**self.form_kwargs).get_course_contexts(),
+            course_context.return_value.objects.filter.return_value,
+        )
+        course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
+        course_access_configuration_get_mock.assert_called_once_with(lti_tool=self.lti_tool)
+        course_context.assert_called_once_with()
+        json_loads_mock.assert_called_once_with(
+            course_access_configuration_get_mock().allowed_course_ids,
+        )
+        course_context().objects.filter.assert_called_once_with(
+            learning_context__context_key__in=json_loads_mock()
+        )
+
+    def test_with_disabled_course_access_configuration_switch(
+        self,
+        get_content_items_choices_mock: MagicMock,  # pylint: disable=unused-argument
+        course_access_configuration_switch_mock: MagicMock,
+        course_access_configuration_get_mock: MagicMock,
+        json_loads_mock: MagicMock,
+        course_context: MagicMock,
+    ):
+        """Test with disabled `COURSE_ACCESS_CONFIGURATION` switch."""
+        course_access_configuration_switch_mock.is_enabled.return_value = False
+
+        self.assertEqual(
+            self.form_class(**self.form_kwargs).get_course_contexts(),
+            course_context.return_value.objects.all.return_value,
+        )
+        course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
+        course_context.assert_called_once_with()
+        course_context().objects.all.assert_called_once_with()
+        course_access_configuration_get_mock.assert_not_called()
+        json_loads_mock.assert_not_called()
+        course_context().objects.filter.assert_not_called()
+
+    @patch(f'{MODULE_PATH}._')
+    def test_without_course_access_configuration(
+        self,
+        gettext_mock: MagicMock,
+        get_content_items_choices_mock: MagicMock,  # pylint: disable=unused-argument
+        course_access_configuration_switch_mock: MagicMock,
+        course_access_configuration_get_mock: MagicMock,
+        json_loads_mock: MagicMock,
+        course_context: MagicMock,
+    ):
+        """Test without CourseAccessConfiguration instance."""
+        course_access_configuration_get_mock.side_effect = CourseAccessConfiguration.DoesNotExist
+
+        with self.assertRaises(DeepLinkingException) as ctxm:
+            self.form_class(**self.form_kwargs).get_course_contexts()
+
+        course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
+        course_access_configuration_get_mock.assert_called_once_with(lti_tool=self.lti_tool)
+        gettext_mock.assert_called_once_with(
+            f'Course access configuration not found: {self.lti_tool.title}.',
+        )
+        self.assertEqual(str(gettext_mock()), str(ctxm.exception))
+        course_context.assert_not_called()
+        course_context().objects.all.assert_not_called()
+        json_loads_mock.assert_not_called()
+        course_context().objects.filter.assert_not_called()
+
+
+@patch(f'{MODULE_PATH}.DeepLinkResource')
+@patch.object(DeepLinkingForm, 'get_content_items_choices')
+class TestDeepLinkingFormGetDeepLinkResources(DeepLinkingFormBaseTestCase):
+    """Test DeepLinkingForm `get_deep_link_resources` method."""
+
     def test_get_deep_link_resources(
         self,
-        deep_linking_form_init: MagicMock,  # pylint: disable=unused-argument
+        get_content_items_choices_mock: MagicMock,  # pylint: disable=unused-argument
         deep_link_resource_mock: MagicMock,
     ):
         """Test `get_deep_link_resources` method."""
         content_item = 'https://example.com'
-        form = self.form_class()
+        form = self.form_class(**self.form_kwargs)
         form.cleaned_data = {'content_items': [content_item]}
 
         self.assertEqual(

--- a/openedx_lti_tool_plugin/resource_link_launch/views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/views.py
@@ -99,8 +99,12 @@ class ResourceLinkLaunchView(LtiToolBaseView):
                     _('Message type is not LtiResourceLinkRequest.'),
                 )
             # Get launch data.
+            # TODO: Replace redundant get_launch_data method with
+            # the DjangoMessageLaunch get_launch_data method.
             launch_data = self.get_launch_data(launch_message)
             # Get identity claims from launch data
+            # TODO: Replace get_identity_claims method with
+            # openedx_lti_tool.utils:get_identity_claims function.
             iss, aud, sub, pii = self.get_identity_claims(launch_data)
             # Check course access permission.
             self.check_course_access_permission(course_id, iss, aud)

--- a/openedx_lti_tool_plugin/tests/test_utils.py
+++ b/openedx_lti_tool_plugin/tests/test_utils.py
@@ -1,8 +1,12 @@
-"""Tests for the openedx_lti_tool_plugin utils module."""
+"""Tests utils module."""
+from unittest.mock import MagicMock, patch
+
 from django.test import TestCase
 
-from openedx_lti_tool_plugin.utils import get_client_id, get_pii_from_claims
+from openedx_lti_tool_plugin.tests import AUD, ISS, SUB
+from openedx_lti_tool_plugin.utils import get_client_id, get_identity_claims, get_pii_from_claims
 
+MODULE_PATH = 'openedx_lti_tool_plugin.utils'
 CLIENT_ID = 'random-client-id'
 
 
@@ -56,3 +60,64 @@ class TestGetPiiFromClaims(TestCase):
                 'locale': '',
             }
         )
+
+
+@patch(f'{MODULE_PATH}.get_client_id')
+@patch(f'{MODULE_PATH}.get_pii_from_claims')
+@patch(f'{MODULE_PATH}.SAVE_PII_DATA')
+class TestGetIdentityClaims(TestCase):
+    """Test `get_identity_claims` function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.launch_data = {
+            'iss': ISS,
+            'aud': AUD,
+            'sub': SUB,
+            'azp': AUD,
+        }
+
+    def test_with_enabled_save_pii_data_switch(
+        self,
+        save_pii_data_mock: MagicMock,
+        get_pii_from_claims_mock: MagicMock,
+        get_client_id_mock: MagicMock,
+    ):
+        """Test with enabled `SAVE_PII_DATA` switch."""
+        save_pii_data_mock.is_enabled.return_value = True
+
+        self.assertEqual(
+            get_identity_claims(self.launch_data),
+            (
+                self.launch_data['iss'],
+                get_client_id_mock.return_value,
+                self.launch_data['sub'],
+                get_pii_from_claims_mock.return_value,
+            )
+        )
+        get_client_id_mock.assert_called_once_with(self.launch_data['aud'], self.launch_data['azp'])
+        save_pii_data_mock.is_enabled.assert_called_once_with()
+        get_pii_from_claims_mock.assert_called_once_with(self.launch_data)
+
+    def test_with_disabled_save_pii_data_switch(
+        self,
+        save_pii_data_mock: MagicMock,
+        get_pii_from_claims_mock: MagicMock,
+        get_client_id_mock: MagicMock,
+    ):
+        """Test with disabled `SAVE_PII_DATA` switch."""
+        save_pii_data_mock.is_enabled.return_value = False
+
+        self.assertEqual(
+            get_identity_claims(self.launch_data),
+            (
+                self.launch_data['iss'],
+                get_client_id_mock.return_value,
+                self.launch_data['sub'],
+                {},
+            )
+        )
+        get_client_id_mock.assert_called_once_with(self.launch_data['aud'], self.launch_data['azp'])
+        save_pii_data_mock.is_enabled.assert_called_once_with()
+        get_pii_from_claims_mock.assert_not_called()


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1201

## Description

This PR adds a filter to the courses available on the DeepLinkingForm. This PR adds a DeepLinkingForm method that either returns all CourseContext objects with all courses on the LMS or a filtered CourseContext queryset with only the courses available per LtiTool using the CourseAccesConfiguration allowed_course_ids field.

## Type of Change

- [x] Add `get_course_contexts` method to DeepLinkingForm Django form.
- [x] Modify `get_content_items_choices` method in the DeepLinkingForm Django form.
- [x] Add or modify all tests related to this code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Run ngrok or any other similar service on LMS: `ngrok http 18000`
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Enable the Django Waffle switch: `openedx_lti_tool_plugin.course_access_configuration`.
- Go to edit the course access configuration of the previously created LTI 1.3 tool config: http://localhost:18000/admin/openedx_lti_tool_plugin/courseaccessconfiguration/
- Edit the "Allowed Course IDs" field and add the courses that should be allowed.
- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms-dstack.kuje.net.eu.org/openedx_lti_tool_plugin/1.3/deep_linking/
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms-dstack.kuje.net.eu.org/openedx_lti_tool_plugin/1.3/deep_linking/
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Go to "Message" on the left sidebar and set these settings:

```
Message type: LtiDeepLinkingRequest
```

- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in new window".
- You should be presented with a form with only the courses that where added to the course access configuration "Allowed Course IDs" field.
- Select one or more courses from the deep linking UI form.
- Click on the "Submit" button.
- The browser should be redirected back to saLTIre,
- The "Sumary" section should show "Verification: Passed" and the "JWT" section should contain the requested courses on the "https://purl.imsglobal.org/spec/lti-dl/claim/content_items" key. 
