### PR TITLE
PADV-717: Use PII data on LtiProfile user

### DIFF
--- a/openedx_lti_tool_plugin/tests/test_utils.py
+++ b/openedx_lti_tool_plugin/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 from openedx_lti_tool_plugin.tests import AUD, ISS, SUB
-from openedx_lti_tool_plugin.utils import get_client_id, get_identity_claims, get_pii_from_claims
+from openedx_lti_tool_plugin.utils import PII_CLAIM_NAMES, get_client_id, get_identity_claims, get_pii_from_claims
 
 MODULE_PATH = 'openedx_lti_tool_plugin.utils'
 CLIENT_ID = 'random-client-id'
@@ -36,30 +36,18 @@ class TestGetClientID(TestCase):
 class TestGetPiiFromClaims(TestCase):
     """Test get_pii_from_claims function."""
 
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.claims = {claim: 'test-value' for claim in PII_CLAIM_NAMES}
+
     def test_with_pii_claims(self):
         """Test with PII claims."""
-        claims = {
-            'email': 'test@example.com',
-            'name': 'random-name',
-            'given_name': 'random-given-name',
-            'family_name': 'random-family-name',
-            'locale': 'random-locale',
-        }
-
-        self.assertEqual(get_pii_from_claims(claims), claims)
+        self.assertEqual(get_pii_from_claims(self.claims), self.claims)
 
     def test_with_missing_pii_claims(self):
         """Test with missing PII claims."""
-        self.assertEqual(
-            get_pii_from_claims({}),
-            {
-                'email': '',
-                'name': '',
-                'given_name': '',
-                'family_name': '',
-                'locale': '',
-            }
-        )
+        self.assertEqual(get_pii_from_claims({}), {})
 
 
 @patch(f'{MODULE_PATH}.get_client_id')

--- a/openedx_lti_tool_plugin/utils.py
+++ b/openedx_lti_tool_plugin/utils.py
@@ -1,9 +1,37 @@
-"""Utilities."""
+"""Utilities.
+
+Attributes:
+    PII_CLAIM_NAMES (list): List of PII (Personal Identifiable Information) claim names.
+        https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+
+"""
 from typing import Optional, Tuple
 
 from django.conf import settings
 
 from openedx_lti_tool_plugin.waffle import SAVE_PII_DATA
+
+PII_CLAIM_NAMES = [
+    'name',
+    'given_name',
+    'middle_name',
+    'family_name',
+    'nickname',
+    'preferred_username',
+    'profile',
+    'picture',
+    'website',
+    'email',
+    'email_verified',
+    'gender',
+    'birthdate',
+    'zoneinfo',
+    'locale',
+    'phone_number',
+    'phone_number_verified',
+    'address',
+    'updated_at',
+]
 
 
 def is_plugin_enabled() -> bool:
@@ -63,13 +91,7 @@ def get_pii_from_claims(claims: dict) -> dict:
         https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 
     """
-    return {
-        'email': claims.get('email', ''),
-        'name': claims.get('name', ''),
-        'given_name': claims.get('given_name', ''),
-        'family_name': claims.get('family_name', ''),
-        'locale': claims.get('locale', ''),
-    }
+    return {key: value for key, value in claims.items() if key in PII_CLAIM_NAMES}
 
 
 def get_identity_claims(launch_data: dict) -> Tuple[str, str, str, dict]:


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-717

## Description

This PR adds the ability to use the "Given name", "Middle name", "Family name", or "Full name" PII claims on the `LtiProfile` `user` profile. This PR also includes various improvements to the handling of the `LtiProfile` save method, the handling of PII data updates, the claims obtained by the `get_pii_from_claims` function and the `ResourceLinkLaunchView` `post` method.

## Type of Change

- [x] Add `LtiProfile` username and name properties.
- [x] Modify `LtiProfile` save method.
- [x] Modify `ResourceLinkLaunchView` post method.
- [x] Modify `get_pii_from_claims` function.
- [x] Add or modify any unit test for all related code.

## Testing:

- Run the LMS: `make dev.up.lms`.
- Run the learning MFE on the host machine: `npm run start`.
- Install `openedx_lti_tool_plugin` on the LMS.
- Run ngrok or any other similar service on LMS: `ngrok http 18000`
- Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
- Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

- Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
- Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

- Restart the LMS: `make dev.restart-container.lms`.
- Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

- Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

- Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
- Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

- Go to the saLTIre platform https://saltire.lti.app/platform
- Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

- Go to "User" on the left sidebar and set these settings:
- Check the checkbox on "Given name", "Middle name", "Family name", and "Full name" fields.
- Click on the "Save" button on the top navbar.
- Click on the dropdown next to the "Connect" button on the top navbar.
- Click on "Open in iframe" or "Open in new window".
- The launch should redirect you to the requested course on the learning MFE.
- Go to https://lms.ngrok.io/account/settings
- The previously configured "Given name", "Middle name", "Family name", or "Full name" values should be seen on the "Full Name" field.
