### PR TITLE
PADV-1394: Improve LTI profile user

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,3 +7,4 @@ pylti1p3                  # LTI 1.3 Advantage Tool implementation
 edx-opaque-keys           # Open edX course and XBlock identities API
 edx-toggles               # Library and utilities for implementing and reporting on feature toggles.
 celery                    # Asynchronous task execution library
+shortuuid                 # Library that generates concise, unambiguous, URL-safe UUIDs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -168,6 +168,8 @@ requests==2.28.1
     # via
     #   -c requirements/constraints.txt
     #   pylti1p3
+shortuuid==1.0.13
+    # via -r requirements/base.in
 six==1.16.0
     # via
     #   -c requirements/constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -277,6 +277,8 @@ rpds-py==0.10.6
     # via
     #   jsonschema
     #   referencing
+shortuuid==1.0.13
+    # via -r requirements/base.txt
 six==1.16.0
     # via
     #   -c requirements/constraints.txt


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1394

## Description

This PR improves the generation of the LtiProfile user, more specifically the LtiProfile user username and email structure, additionally the LtiProfile name property was modified and the name used on the user profile was truncated to 255 characters in case a very large name is used to avoid error with the field max_length.

## Type of Change

- [x] Added `shortuuid` base requirement.
- [x] Added `LtiProfile` `short_uuid` property.
- [x] Added `LtiProfile` `given_name` property.
- [x] Added `LtiProfile` `middle_name` property.
- [x] Added `LtiProfile` `family_name` property.
- [x] Added `LtiProfile` `user_collision` method.
- [x] Added `LtiProfile` `configure_user` method.
- [x] Modify `LtiProfile` `name` property.
- [x] Modify `LtiProfile` save method.
- [x] Add or modify any unit test for all related code.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Go to "User" on the left sidebar and set these settings:
17. Check the checkbox on "Given name", and "Family name" fields.
18. Click on the "Save" button on the top navbar.
19. Click on the dropdown next to the "Connect" button on the top navbar.
20. Click on "Open in iframe" or "Open in new window".
21. The launch should redirect you to the requested course on the learning MFE.
22. Go to https://lms.ngrok.io/account/settings
23. The username should show like "givennamefamilynameinitial.short_uuid"
24. The email should show like "uuid@openedx_lti_tool_plugin"
25. Repeat steps 16 - 22.
26. The username should show like "short_uuid"
27. The email should show like "uuid@openedx_lti_tool_plugin"
