### PR TITLE
PADV-1574: Improve LtiProfile name and username property

### DIFF
--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -1,5 +1,6 @@
 """Test models module."""
 import random
+import re
 import string
 import uuid
 from unittest.mock import MagicMock, PropertyMock, call, patch
@@ -22,7 +23,9 @@ NAME = 'random-name'
 GIVEN_NAME = 'random-given-name'
 MIDDLE_NAME = 'random-middle-name'
 FAMILY_NAME = 'random-family-name'
-GIVEN_NAME_LARGER = ''.join(random.choices(string.ascii_lowercase, k=300))
+GIVEN_NAME_LARGER = ''.join(random.choices([string.ascii_lowercase, string.punctuation], k=300))
+UNICODE_USERNAME_GIVEN_NAME = re.sub(r'\W+', '', f'{GIVEN_NAME_LARGER[:30]}')
+UNICODE_USERNAME_NAME = re.sub(r'\W+', '', f'{GIVEN_NAME_LARGER[:30]}{FAMILY_NAME[:1]}')
 
 
 @ddt.ddt
@@ -202,6 +205,12 @@ class TestLtiProfile(TestCase):
     @ddt.data(
         (
             {
+                'name': NAME,
+            },
+            NAME,
+        ),
+        (
+            {
                 'given_name': GIVEN_NAME,
                 'middle_name': MIDDLE_NAME,
                 'family_name': FAMILY_NAME,
@@ -231,7 +240,7 @@ class TestLtiProfile(TestCase):
             {
                 'given_name': GIVEN_NAME_LARGER,
             },
-            f'{GIVEN_NAME_LARGER.lower()[:30]}.',
+            f'{UNICODE_USERNAME_GIVEN_NAME.lower()}.',
         ),
         (
             False,
@@ -239,7 +248,7 @@ class TestLtiProfile(TestCase):
                 'given_name': GIVEN_NAME_LARGER,
                 'family_name': FAMILY_NAME,
             },
-            f'{GIVEN_NAME_LARGER.lower()[:30]}{FAMILY_NAME.lower()[:1]}.',
+            f'{UNICODE_USERNAME_NAME.lower()}.',
         ),
         (False, {}, ''),
         (True, {}, ''),


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1574

## Description

This PR improves the generation of the LtiProfile user, more specifically the LtiProfile user username and name properties. The name property was modified to make use of the [name PII claim](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) if present and the username property was modified to clean it against a regex to make sure the given_name and family_name values don't contain values that will generate issues with [UnicodeUsernameValidator](https://docs.djangoproject.com/en/3.2/ref/contrib/auth/#django.contrib.auth.validators.UnicodeUsernameValidator) used on the User username field.

## Type of Change

- [x] Modified `LtiProfile` `name` property.
- [x] Modified `LtiProfile` `username` property.
- [x] Add or modify any unit test for all related code.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Go to "User" on the left sidebar and set these settings:
17. Check the checkbox on "Given name", and "Family name" fields.
18. Click on the "Save" button on the top navbar.
19. Click on the dropdown next to the "Connect" button on the top navbar.
20. Click on "Open in iframe" or "Open in new window".
21. The launch should redirect you to the requested course on the learning MFE.
22. Go to https://lms.ngrok.io/account/settings
23. The username should show like "givennamefamilynameinitial.short_uuid"
24. The email should show like "uuid@openedx_lti_tool_plugin"
25. Repeat steps 16 - 22.
26. The username should show like "short_uuid"
27. The email should show like "uuid@openedx_lti_tool_plugin"
