### PR TITLE
PADV-1854: LtiProfile email domain

### DIFF
--- a/openedx_lti_tool_plugin/apps.py
+++ b/openedx_lti_tool_plugin/apps.py
@@ -3,9 +3,21 @@ from django.apps import AppConfig
 
 
 class OpenEdxLtiToolPluginConfig(AppConfig):
-    """Configuration for the openedx_lti_tool_plugin Django application."""
+    """Open edX LTI Tool Plugin application configuration.
+
+    Attributes:
+        name (str): Application name.
+        domain_name (str): Application domain name.
+        verbose_name (str): Vebose application name.
+        plugin_app (dict): Open edX plugin application settings.
+
+    ...edx-django-utils - Django App Plugins:
+        https://github.com/openedx/edx-django-utils/tree/master/edx_django_utils/plugins
+
+    """
 
     name = 'openedx_lti_tool_plugin'
+    domain_name = 'openedx-lti-tool-plugin.internal'
     verbose_name = 'Open edX LTI Tool Plugin'
     plugin_app = {
         'url_config': {

--- a/openedx_lti_tool_plugin/models.py
+++ b/openedx_lti_tool_plugin/models.py
@@ -136,11 +136,12 @@ class LtiProfile(models.Model):
     @property
     def email(self) -> str:
         """str: Email address."""
-        # Get email from user.
+        # Return email from `user` attribute.
         if getattr(self, 'user', None):
             return self.user.email
-        # Generate email string.
-        return f'{self.uuid}@{app_config.name}'
+
+        # Build email using UUID and app domain_name.
+        return f'{self.uuid}@{app_config.domain_name}'
 
     def user_collision(self) -> bool:
         """Check for user collision.

--- a/openedx_lti_tool_plugin/tests/test_apps.py
+++ b/openedx_lti_tool_plugin/tests/test_apps.py
@@ -1,21 +1,18 @@
-"""Tests for the openedx_lti_tool_plugin apps module."""
+"""Tests apps module."""
 from django.test import TestCase
 from jsonschema import validate
 
-from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as AppConfig
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig
 
 
 class TestOpenEdxLtiToolPluginConfig(TestCase):
-    """Test openedx_lti_tool_plugin app config."""
+    """Test OpenEdxLtiToolPluginConfig class."""
 
-    def test_plugin_app_schema(self):
-        """
-        Test class plugin_app configuration schema.
+    app_config = OpenEdxLtiToolPluginConfig
 
-        For more information on this test, see:
-        https://python-jsonschema.readthedocs.io/en/stable/
-        """
-        url_config_properties = {
+    def test_plugin_app_jsonschema(self):
+        """Test `plugin_app` attribute JSON Schema."""
+        url_config = {
             'type': 'object',
             'required': ['regex', 'namespace', 'relative_path'],
             'properties': {
@@ -24,7 +21,7 @@ class TestOpenEdxLtiToolPluginConfig(TestCase):
                 'relative_path': {'type': 'string'},
             },
         }
-        settings_config_properties = {
+        settings_config = {
             'type': 'object',
             'required': ['common', 'production', 'test'],
             'patternProperties': {
@@ -42,16 +39,17 @@ class TestOpenEdxLtiToolPluginConfig(TestCase):
                 'url_config': {
                     'type': 'object',
                     'required': ['lms.djangoapp'],
-                    'patternProperties': {'^.*$': url_config_properties},
+                    'patternProperties': {'^.*$': url_config},
                 },
                 'settings_config': {
                     'type': 'object',
                     'required': ['lms.djangoapp'],
-                    'patternProperties': {'^.*$': settings_config_properties},
+                    'patternProperties': {'^.*$': settings_config},
                 },
             },
         }
 
-        validate(instance=AppConfig.plugin_app, schema=schema)
-        self.assertEqual(AppConfig.name, 'openedx_lti_tool_plugin')
-        self.assertEqual(AppConfig.verbose_name, 'Open edX LTI Tool Plugin')
+        validate(instance=self.app_config.plugin_app, schema=schema)
+        self.assertEqual(self.app_config.name, 'openedx_lti_tool_plugin')
+        self.assertEqual(self.app_config.domain_name, 'openedx-lti-tool-plugin.internal')
+        self.assertEqual(self.app_config.verbose_name, 'Open edX LTI Tool Plugin')

--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -270,7 +270,7 @@ class TestLtiProfile(TestCase):
         """Test email property."""
         self.assertEqual(
             self.lti_profile.email,
-            f'{self.lti_profile.uuid}@{app_config.name}',
+            f'{self.lti_profile.uuid}@{app_config.domain_name}',
         )
 
     def test_str_method(self):


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1854

## Description

This PR improves the generation of the LtiProfile user, more specifically the LtiProfile user email property. The email property was modified to contain a top-level domain in his address to avoid issues with the regex validation of [EmailValidator](https://docs.djangoproject.com/en/5.1/ref/validators/#emailvalidator). 

## Type of Change

- [x] Added `OpenEdxLtiToolPluginConfig` `internal_domain` property.
- [x] Modified `LtiProfile` `email` property.
- [x] Add or modify any unit test for all related code.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Go to "User" on the left sidebar and set these settings:
17. Check the checkbox on "Given name", and "Family name" fields.
18. Click on the "Save" button on the top navbar.
19. Click on the dropdown next to the "Connect" button on the top navbar.
20. Click on "Open in iframe" or "Open in new window".
21. The launch should redirect you to the requested course on the learning MFE.
22. Go to https://lms.ngrok.io/account/settings
23. The email should show like "uuid@openedx_lti_tool_plugin.internal"

If a previous launch using the same identity was `used` before testing with this PR, you should go to the Django admin and remove the LtiProfile to such identity to restart the `User` generation of this identity `LtiProfile`. Otherwise on the saLTIre platform, go to the left sidebar "User" section and modify the `ID` field to use a different identity for the launch.
