### PR TITLE
PADV-1922: Improve LtiProfile username generation

### DIFF
--- a/openedx_lti_tool_plugin/models.py
+++ b/openedx_lti_tool_plugin/models.py
@@ -111,27 +111,33 @@ class LtiProfile(models.Model):
     @property
     def name(self) -> str:
         """str: Name."""
-        # Return the name from pii if available
+        # Return name from `pii` field.
         if name := self.pii.get('name', ''):
             return name
-        # Create list with available name parts.
-        parts = [self.given_name, self.middle_name, self.family_name]
-        # Construct the name based on list of available name parts.
-        return ' '.join(part for part in parts if part)
+
+        # Build list with available name parts.
+        name_parts = [self.given_name, self.middle_name, self.family_name]
+
+        # Build name using list of available name parts.
+        return ' '.join(part for part in name_parts if part)
 
     @property
     def username(self) -> str:
         """str: Username."""
-        # Get username from user.
+        # Return username from `user` attribute.
         if getattr(self, 'user', None):
             return self.user.username
-        # Generate username with short UUID.
-        if not self.given_name:
+
+        try:
+            # Return username using `name` and short UUID.
+            name = self.name.split()
+            name = name[0][:8].lower()
+            name = re.sub(r'[\W_]+', '', name)
+
+            return f'{name}.{self.short_uuid}'
+        except IndexError:
+            # Return username using short UUID.
             return f'{self.short_uuid}'
-        # Get cleaned unicode name.
-        name = re.sub(r'\W+', '', f'{self.given_name[:30]}{self.family_name[:1]}')
-        # Generate username with lowercase name and short UUID.
-        return f'{name.lower()}.{self.short_uuid}'
 
     @property
     def email(self) -> str:

--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -24,8 +24,7 @@ GIVEN_NAME = 'random-given-name'
 MIDDLE_NAME = 'random-middle-name'
 FAMILY_NAME = 'random-family-name'
 GIVEN_NAME_LARGER = ''.join(random.choices([string.ascii_lowercase, string.punctuation], k=300))
-UNICODE_USERNAME_GIVEN_NAME = re.sub(r'\W+', '', f'{GIVEN_NAME_LARGER[:30]}')
-UNICODE_USERNAME_NAME = re.sub(r'\W+', '', f'{GIVEN_NAME_LARGER[:30]}{FAMILY_NAME[:1]}')
+UNICODE_USERNAME_GIVEN_NAME = re.sub(r'[\W_]+', '', f'{GIVEN_NAME_LARGER[:8]}').lower()
 
 
 @ddt.ddt
@@ -235,23 +234,19 @@ class TestLtiProfile(TestCase):
         self.assertEqual(self.lti_profile.name, name_return)
 
     @ddt.data(
-        (
-            False,
-            {
-                'given_name': GIVEN_NAME_LARGER,
-            },
-            f'{UNICODE_USERNAME_GIVEN_NAME.lower()}.',
-        ),
-        (
-            False,
-            {
-                'given_name': GIVEN_NAME_LARGER,
-                'family_name': FAMILY_NAME,
-            },
-            f'{UNICODE_USERNAME_NAME.lower()}.',
-        ),
         (False, {}, ''),
+        (False, {'name': ''}, ''),
+        (
+            False,
+            {'name': f'{GIVEN_NAME_LARGER} {MIDDLE_NAME} {FAMILY_NAME}'},
+            f'{UNICODE_USERNAME_GIVEN_NAME}.',
+        ),
         (True, {}, ''),
+        (
+            True,
+            {'name': f'{GIVEN_NAME_LARGER} {MIDDLE_NAME} {FAMILY_NAME}'},
+            '',
+        ),
     )
     @ddt.unpack
     def test_username_property(self, has_user: bool, name_data: dict, name_return: str):


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1922

## Description

This PR improves the generation of the LtiProfile user, more specifically the LtiProfile user username and name properties. The username property was modified to clean it against a regex that removes all special characters some of which weren't covered before, also the process to obtain the name used on the username was modified to use the values from the name property instead of using the `pii` given_name and family_name value, the name property docstrings were also modified.

## Type of Change

- [x] Modified `LtiProfile` `name` property.
- [x] Modified `LtiProfile` `username` property.
- [x] Add or modify any unit test for all related code.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Go to "User" on the left sidebar and set these settings:
17. Check the checkbox on "Given name", and "Family name" fields.
18. Click on the "Save" button on the top navbar.
19. Click on the dropdown next to the "Connect" button on the top navbar.
20. Click on "Open in iframe" or "Open in new window".
21. The launch should redirect you to the requested course on the learning MFE.
22. Go to https://lms.ngrok.io/account/settings
23. The username should show like "name.short_uuid"
24. Repeat steps 16 - 22.
25. The username should show like "short_uuid"
