### PR TITLE
PADV-2048: Remove X-Frame-Options from DeepLinkingFormView, LtiToolLoginView

### DIFF
--- a/openedx_lti_tool_plugin/deep_linking/views.py
+++ b/openedx_lti_tool_plugin/deep_linking/views.py
@@ -69,6 +69,7 @@ class DeepLinkingView(LTIToolView):
             return self.http_response_error(exc)
 
 
+@method_decorator(xframe_options_exempt, name='dispatch')
 class DeepLinkingFormView(LTIToolView):
     """Deep Linking Form View.
 

--- a/openedx_lti_tool_plugin/views.py
+++ b/openedx_lti_tool_plugin/views.py
@@ -5,6 +5,7 @@ from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.http.request import HttpRequest
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import View
 from pylti1p3.contrib.django import DjangoOIDCLogin
@@ -47,7 +48,7 @@ class LTIToolView(LTIToolMixin, View):
     """LTI Tool View."""
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator([csrf_exempt, xframe_options_exempt], name='dispatch')
 class LtiToolLoginView(LTIToolView):
     """
     LTI 1.3 third-party login view.


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-2048

## Description

This PR adds the `xframe_options_exempt` to the `DeepLinkingFormView` and `LtiToolLoginView` to make these views exempt from the X-Frame-Options DENY HTTP header added to the views response by the Django `XFrameOptionsMiddleware`.

## Type of Change

- [x] Add `xframe_options_exempt` to `DeepLinkingFormView` and `LtiToolLoginView`.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Install `openedx_lti_tool_plugin` on the LMS.
3. Run ngrok or any other similar service on LMS: `ngrok http 18000`
4. Add required settings to LMS.
	
```python
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
```

5. Create a new LTI 1.3 tool key config: https://lms.ngrok.io/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
6. Create a new LTI 1.3 tool config: https://lms.ngrok.io/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

7. Go to the saLTIre platform https://saltire.lti.app/platform
8. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/deep_linking/
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/deep_linking/
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

9. Go to "Message" on the left sidebar and set these settings:

```
Message type: LtiDeepLinkingRequest
```

10. Click on the "Save" button on the top navbar.
11. Click on the dropdown next to the "Connect" button on the top navbar.
12. Click on "Open in iframe".
13. You should be redirected to the Deep Linking Form View.
14. Select one or more rows from the table.
15. Click on the "Submit" button.
16. The browser should be redirected back to saLTIre,
17. The "Sumary" section should show "Verification: Passed" and the "JWT" section should contain the content items from the selected rows in the table.