### PR TITLE
PADV-2053: Improve ResourceLinkLaunchView and Deep Linking resource ID handling

### DIFF
--- a/openedx_lti_tool_plugin/deep_linking/api/v1/serializers.py
+++ b/openedx_lti_tool_plugin/deep_linking/api/v1/serializers.py
@@ -1,7 +1,9 @@
 """Django REST Framework Serializers."""
+from django.http.request import HttpRequest
+from django.urls import reverse
 from rest_framework import serializers
 
-from openedx_lti_tool_plugin.deep_linking.utils import build_resource_link_launch_url
+from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
 from openedx_lti_tool_plugin.models import CourseContext
 
 
@@ -16,18 +18,34 @@ class CourseContentItemSerializer(serializers.Serializer):  # pylint: disable=ab
     type = serializers.ReadOnlyField(default='ltiResourceLink')
     url = serializers.SerializerMethodField()
     title = serializers.CharField(allow_blank=True)
+    custom = serializers.SerializerMethodField()
 
-    def get_url(self, course_context: CourseContext):
+    def get_url(self, *args) -> str:
         """Get Content Item URL.
+
+        Args:
+            *args: Variable length argument list.
+
+        Returns:
+            LTI Resource Link Launch URL.
+
+        """
+        request: HttpRequest = self.context.get('request')
+
+        return request.build_absolute_uri(
+            reverse(f'{app_config.name}:1.3:resource-link:launch'),
+        )
+
+    def get_custom(self, course_context: CourseContext):
+        """Get Content Item Custom Parameters.
 
         Args:
             course_context: CourseContext object.
 
         Returns:
-            Course LTI Resource Link Launch URL.
+            Content Item Custom Parameters.
 
         """
-        return build_resource_link_launch_url(
-            self.context.get('request'),
-            course_context.course_id,
-        )
+        return {
+            'resourceId': str(course_context.course_id),
+        }

--- a/openedx_lti_tool_plugin/deep_linking/forms.py
+++ b/openedx_lti_tool_plugin/deep_linking/forms.py
@@ -20,6 +20,12 @@ class DeepLinkingForm(forms.Form):
                 'type': {'type': 'string'},
                 'url': {'type': 'string'},
                 'title': {'type': 'string'},
+                'custom': {
+                    'type': 'object',
+                    'properties': {
+                        'resourceId': {'type': 'string'},
+                    },
+                },
             },
             'additionalProperties': True,
         },
@@ -49,9 +55,10 @@ class DeepLinkingForm(forms.Form):
 
         for content_item in self.cleaned_data.get('content_items', []):
             deep_link_resource = DeepLinkResource()
-            deep_link_resource.set_type(content_item.get('type'))
-            deep_link_resource.set_title(content_item.get('title'))
-            deep_link_resource.set_url(content_item.get('url'))
+            deep_link_resource.set_type(content_item.get('type', ''))
+            deep_link_resource.set_title(content_item.get('title', ''))
+            deep_link_resource.set_url(content_item.get('url', ''))
+            deep_link_resource.set_custom_params(content_item.get('custom', {}))
             deep_link_resources.append(deep_link_resource)
 
         self.cleaned_data['deep_link_resources'] = deep_link_resources

--- a/openedx_lti_tool_plugin/deep_linking/tests/test_forms.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/test_forms.py
@@ -20,6 +20,9 @@ class TestDeepLinkingForm(TestCase):
             'type': 'test-type',
             'url': 'tset-title',
             'title': 'http://test.com',
+            'custom': {
+                'resourceId': 'test-resource-id',
+            },
         }
 
     def test_class_attributes(self):
@@ -34,6 +37,12 @@ class TestDeepLinkingForm(TestCase):
                         'type': {'type': 'string'},
                         'url': {'type': 'string'},
                         'title': {'type': 'string'},
+                        'custom': {
+                            'type': 'object',
+                            'properties': {
+                                'resourceId': {'type': 'string'},
+                            },
+                        },
                     },
                     'additionalProperties': True,
                 },
@@ -62,4 +71,7 @@ class TestDeepLinkingForm(TestCase):
         )
         deep_link_resource_mock().set_url.assert_called_once_with(
             self.content_item['url'],
+        )
+        deep_link_resource_mock().set_custom_params.assert_called_once_with(
+            self.content_item['custom'],
         )

--- a/openedx_lti_tool_plugin/deep_linking/tests/test_utils.py
+++ b/openedx_lti_tool_plugin/deep_linking/tests/test_utils.py
@@ -3,35 +3,11 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
-from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
 from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
 from openedx_lti_tool_plugin.deep_linking.tests import MODULE_PATH
-from openedx_lti_tool_plugin.deep_linking.utils import build_resource_link_launch_url, validate_deep_linking_message
+from openedx_lti_tool_plugin.deep_linking.utils import validate_deep_linking_message
 
 MODULE_PATH = f'{MODULE_PATH}.utils'
-
-
-@patch(f'{MODULE_PATH}.reverse')
-class TestBuildResourceLinkLaunchUrl(TestCase):
-    """Test build_resource_link_launch_url function."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        super().setUp()
-        self.function = build_resource_link_launch_url
-        self.request = MagicMock()
-        self.course_id = 'test-course-id'
-
-    def test_with_course_id(self, reverse_mock: MagicMock):
-        """Test with course ID."""
-        self.assertEqual(
-            self.function(self.request, self.course_id),
-            self.request.build_absolute_uri.return_value,
-        )
-        reverse_mock.assert_called_once_with(
-            f'{app_config.name}:1.3:resource-link:launch-course',
-            kwargs={'course_id': self.course_id},
-        )
 
 
 class TestValidateDeepLinkingMessage(TestCase):

--- a/openedx_lti_tool_plugin/deep_linking/utils.py
+++ b/openedx_lti_tool_plugin/deep_linking/utils.py
@@ -1,30 +1,8 @@
 """Utilities."""
-from django.http.request import HttpRequest
-from django.urls import reverse
 from django.utils.translation import gettext as _
 from pylti1p3.contrib.django import DjangoMessageLaunch
 
-from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
 from openedx_lti_tool_plugin.deep_linking.exceptions import DeepLinkingException
-
-
-def build_resource_link_launch_url(request: HttpRequest, course_id: str) -> str:
-    """Build LTI 1.3 resource link launch URL.
-
-    Args:
-        request: HttpRequest object.
-        course_id: Course ID string.
-
-    Returns:
-        An absolute LTI 1.3 resource link launch URL.
-
-    """
-    return request.build_absolute_uri(
-        reverse(
-            f'{app_config.name}:1.3:resource-link:launch-course',
-            kwargs={'course_id': course_id},
-        )
-    )
 
 
 def validate_deep_linking_message(message: DjangoMessageLaunch):

--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_urls.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_urls.py
@@ -3,31 +3,27 @@ from django.test import TestCase
 from django.urls import resolve, reverse
 
 from openedx_lti_tool_plugin.resource_link_launch.views import ResourceLinkLaunchView
-from openedx_lti_tool_plugin.tests import COURSE_ID, USAGE_KEY
 
 
 class TestResourceLinkLaunchViewUrlPatterns(TestCase):
     """Test ResourceLinkLaunchView Django URL configuration."""
 
-    def test_launch_course_url(self):
-        """Test `launch-course` URL."""
+    def test_launch_url(self):
+        """Test launch URL."""
         self.assertEqual(
             resolve(
-                reverse(
-                    '1.3:resource-link:launch-course',
-                    args=[COURSE_ID],
-                ),
+                reverse('1.3:resource-link:launch'),
             ).func.view_class,
             ResourceLinkLaunchView,
         )
 
-    def test_launch_usage_key(self):
-        """Test `launch-usage-key` URL."""
+    def test_launch_resource_id(self):
+        """Test launch-resource-id URL."""
         self.assertEqual(
             resolve(
                 reverse(
-                    '1.3:resource-link:launch-usage-key',
-                    args=[COURSE_ID, USAGE_KEY],
+                    '1.3:resource-link:launch-resource-id',
+                    args=['resource-id'],
                 ),
             ).func.view_class,
             ResourceLinkLaunchView,

--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
@@ -1,12 +1,12 @@
 """Tests views module."""
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
-from ddt import data, ddt
+import ddt
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys import InvalidKeyError
 from pylti1p3.exception import LtiException
 
 from openedx_lti_tool_plugin.edxapp_wrapper.student_module import course_enrollment_exception
@@ -16,13 +16,16 @@ from openedx_lti_tool_plugin.resource_link_launch.tests import MODULE_PATH
 from openedx_lti_tool_plugin.resource_link_launch.views import (
     AGS_CLAIM_ENDPOINT,
     AGS_SCORE_SCOPE,
+    CUSTOM_CLAIM,
     ResourceLinkLaunchView,
 )
-from openedx_lti_tool_plugin.tests import AUD, COURSE_ID, ISS, SUB, USAGE_KEY
+from openedx_lti_tool_plugin.tests import AUD, COURSE_ID, ISS, SUB
 
 MODULE_PATH = f'{MODULE_PATH}.views'
 COURSE_KEY = 'random-course-key'
-LAUNCH_DATA = {'iss': ISS, 'aud': [AUD], 'sub': SUB}
+IDENTITY_CLAIMS = {'iss': ISS, 'aud': [AUD], 'sub': SUB}
+CUSTOM_PARAMETERS = {'x': 'x'}
+LAUNCH_DATA = {**IDENTITY_CLAIMS, CUSTOM_CLAIM: CUSTOM_PARAMETERS}
 LTI_PROFILE = 'random-lti-profile'
 PII = {'x': 'x'}
 
@@ -36,16 +39,22 @@ class ResourceLinkLaunchViewBaseTestCase(TestCase):
         self.view_class = ResourceLinkLaunchView
         self.factory = RequestFactory()
         self.user = MagicMock(id='x', username='x', email='x@example.com', is_authenticated=True)
+        self.course_key = MagicMock()
+        self.usage_key = MagicMock()
+        self.resource_id = 'test-resource-id'
 
 
+@ddt.ddt
 @patch.object(ResourceLinkLaunchView, 'tool_config', new_callable=PropertyMock)
 @patch.object(ResourceLinkLaunchView, 'tool_storage', new_callable=PropertyMock)
 @patch(f'{MODULE_PATH}.DjangoMessageLaunch')
+@patch.object(ResourceLinkLaunchView, 'get_resource_id')
+@patch.object(ResourceLinkLaunchView, 'get_opaque_keys')
+@patch.object(ResourceLinkLaunchView, 'validate_opaque_keys')
 @patch(f'{MODULE_PATH}.get_identity_claims')
 @patch.object(ResourceLinkLaunchView, 'check_course_access_permission')
 @patch.object(LtiProfile.objects, 'update_or_create', return_value=(LTI_PROFILE, None))
 @patch.object(ResourceLinkLaunchView, 'authenticate_and_login')
-@patch.object(CourseKey, 'from_string', return_value=COURSE_KEY)
 @patch.object(ResourceLinkLaunchView, 'enroll')
 @patch.object(ResourceLinkLaunchView, 'get_launch_response', return_value=(MagicMock(), COURSE_KEY))
 @patch.object(ResourceLinkLaunchView, 'handle_ags')
@@ -55,31 +64,32 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
     def setUp(self):
         """Set up test fixtures."""
         super().setUp()
-        self.url = reverse('1.3:resource-link:launch-course', args=[COURSE_ID])
+        self.url = reverse('1.3:resource-link:launch-resource-id', args=[COURSE_ID])
         self.request = self.factory.post(self.url)
         self.request.user = self.user
         self.enrollment_mock = MagicMock()
 
-    def test_with_course_launch(
+    def test_with_resource_id(
         self,
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
-        course_key_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
         lti_profile_update_or_create_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
+        validate_opaque_keys_mock: MagicMock,
+        get_opaque_keys_mock: MagicMock,
+        get_resource_id_mock: MagicMock,
         message_launch_mock: MagicMock,
         tool_storage_mock: MagicMock,
         tool_conf_mock: MagicMock,
     ):
-        """Test with course launch."""
+        """Test with resource_id."""
+        message_launch_mock.return_value.get_launch_data.return_value = LAUNCH_DATA
+        get_opaque_keys_mock.return_value = (self.course_key, self.usage_key)
         get_identity_claims_mock.return_value = (ISS, AUD, SUB, PII)
-        get_launch_response_mock.return_value = (
-            response_mock := MagicMock(),
-            COURSE_ID,
-        )
+        get_launch_response_mock.return_value = MagicMock()
 
         response = self.view_class.as_view()(self.request, COURSE_ID)
 
@@ -90,10 +100,21 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         )
         message_launch_mock().is_resource_launch.assert_called_once_with()
         message_launch_mock().get_launch_data.assert_called_once_with()
+        get_resource_id_mock.assert_called_once_with(COURSE_ID, CUSTOM_PARAMETERS)
+        get_opaque_keys_mock.assert_called_once_with(get_resource_id_mock())
+        validate_opaque_keys_mock.assert_called_once_with(
+            self.course_key,
+            self.usage_key,
+            get_resource_id_mock(),
+        )
         get_identity_claims_mock.assert_called_once_with(
             message_launch_mock().get_launch_data(),
         )
-        check_course_access_permission_mock.assert_called_once_with(COURSE_ID, ISS, AUD)
+        check_course_access_permission_mock.assert_called_once_with(
+            str(self.course_key),
+            ISS,
+            AUD,
+        )
         lti_profile_update_or_create_mock.assert_called_once_with(
             platform_id=ISS,
             client_id=AUD,
@@ -101,86 +122,24 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
             defaults={'pii': PII},
         )
         authenticate_and_login_mock.assert_called_once_with(self.request, ISS, AUD, SUB)
-        course_key_mock.assert_called_once_with(COURSE_ID)
         enroll_mock.assert_called_once_with(
             self.request,
             authenticate_and_login_mock(),
-            'random-course-key',
+            self.course_key,
         )
         get_launch_response_mock.assert_called_once_with(
             self.request,
             authenticate_and_login_mock(),
-            COURSE_ID,
-            '',
+            self.course_key,
+            self.usage_key,
         )
         handle_ags_mock.assert_called_once_with(
             message_launch_mock(),
             message_launch_mock().get_launch_data(),
             lti_profile_update_or_create_mock()[0],
-            COURSE_ID,
+            get_resource_id_mock(),
         )
-        self.assertEqual(response, response_mock)
-
-    def test_with_unit_or_component_launch(
-        self,
-        handle_ags_mock: MagicMock,
-        get_launch_response_mock: MagicMock,
-        enroll_mock: MagicMock,
-        course_key_mock: MagicMock,
-        authenticate_and_login_mock: MagicMock,
-        lti_profile_update_or_create_mock: MagicMock,
-        check_course_access_permission_mock: MagicMock,
-        get_identity_claims_mock: MagicMock,
-        message_launch_mock: MagicMock,
-        tool_storage_mock: MagicMock,
-        tool_conf_mock: MagicMock,
-    ):
-        """Test with unit or component launch."""
-        get_identity_claims_mock.return_value = (ISS, AUD, SUB, PII)
-        get_launch_response_mock.return_value = (
-            response_mock := MagicMock(),
-            USAGE_KEY,
-        )
-
-        response = self.view_class.as_view()(self.request, COURSE_ID, USAGE_KEY)
-
-        message_launch_mock.assert_called_once_with(
-            self.request,
-            tool_conf_mock(),
-            launch_data_storage=tool_storage_mock(),
-        )
-        message_launch_mock().is_resource_launch.assert_called_once_with()
-        message_launch_mock().get_launch_data.assert_called_once_with()
-        get_identity_claims_mock.assert_called_once_with(
-            message_launch_mock().get_launch_data(),
-        )
-        check_course_access_permission_mock.assert_called_once_with(COURSE_ID, ISS, AUD)
-        lti_profile_update_or_create_mock.assert_called_once_with(
-            platform_id=ISS,
-            client_id=AUD,
-            subject_id=SUB,
-            defaults={'pii': PII},
-        )
-        authenticate_and_login_mock.assert_called_once_with(self.request, ISS, AUD, SUB)
-        course_key_mock.assert_called_once_with(COURSE_ID)
-        enroll_mock.assert_called_once_with(
-            self.request,
-            authenticate_and_login_mock(),
-            'random-course-key',
-        )
-        get_launch_response_mock.assert_called_once_with(
-            self.request,
-            authenticate_and_login_mock(),
-            COURSE_ID,
-            USAGE_KEY,
-        )
-        handle_ags_mock.assert_called_once_with(
-            message_launch_mock(),
-            message_launch_mock().get_launch_data(),
-            lti_profile_update_or_create_mock()[0],
-            USAGE_KEY,
-        )
-        self.assertEqual(response, response_mock)
+        self.assertEqual(response, get_launch_response_mock())
 
     @patch(f'{MODULE_PATH}._')
     def test_without_resource_link_launch(
@@ -189,20 +148,21 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
-        course_key_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
         lti_profile_update_or_create_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
+        validate_opaque_keys_mock: MagicMock,
+        get_opaque_keys_mock: MagicMock,
+        get_resource_id_mock: MagicMock,
         message_launch_mock: MagicMock,
         tool_storage_mock: MagicMock,
         tool_conf_mock: MagicMock,
     ):
         """Test without a resource link launch message type."""
-        get_identity_claims_mock.return_value = (ISS, AUD, SUB, PII)
         message_launch_mock.return_value.is_resource_launch.return_value = False
 
-        response = self.view_class.as_view()(self.request, COURSE_ID, USAGE_KEY)
+        response = self.view_class.as_view()(self.request, COURSE_ID)
 
         self.assertEqual(response.status_code, 400)
         message_launch_mock.assert_called_once_with(
@@ -219,11 +179,13 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
             any_order=True,
         )
         message_launch_mock().get_launch_data.assert_not_called()
+        get_resource_id_mock.assert_not_called()
+        get_opaque_keys_mock.assert_not_called()
+        validate_opaque_keys_mock.assert_not_called()
         get_identity_claims_mock.assert_not_called()
         check_course_access_permission_mock.assert_not_called()
         lti_profile_update_or_create_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
-        course_key_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
         handle_ags_mock.assert_not_called()
@@ -237,11 +199,13 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
-        course_key_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
         lti_profile_update_or_create_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
+        validate_opaque_keys_mock: MagicMock,
+        get_opaque_keys_mock: MagicMock,
+        get_resource_id_mock: MagicMock,
         message_launch_mock: MagicMock,
         tool_storage_mock: MagicMock,
         tool_conf_mock: MagicMock,
@@ -250,7 +214,7 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         message_launch_mock.side_effect = LtiException('Error message')
 
         self.assertEqual(
-            self.view_class.as_view()(self.request, COURSE_ID, USAGE_KEY),
+            self.view_class.as_view()(self.request, COURSE_ID),
             logged_http_response_bad_request_mock(),
         )
         message_launch_mock.assert_called_once_with(
@@ -260,11 +224,13 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         )
         gettext_mock.assert_called_once_with('LTI 1.3 Resource Link Launch: Error message')
         message_launch_mock.return_value.get_launch_data.assert_not_called()
+        get_resource_id_mock.assert_not_called()
+        get_opaque_keys_mock.assert_not_called()
+        validate_opaque_keys_mock.assert_not_called()
         get_identity_claims_mock.assert_not_called()
         check_course_access_permission_mock.assert_not_called()
         lti_profile_update_or_create_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
-        course_key_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
         handle_ags_mock.assert_not_called()
@@ -278,11 +244,13 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
-        course_key_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
         lti_profile_update_or_create_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
+        validate_opaque_keys_mock: MagicMock,
+        get_opaque_keys_mock: MagicMock,
+        get_resource_id_mock: MagicMock,
         message_launch_mock: MagicMock,
         tool_storage_mock: MagicMock,
         tool_conf_mock: MagicMock,
@@ -291,7 +259,7 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         message_launch_mock.side_effect = LtiToolLaunchException('Error message')
 
         self.assertEqual(
-            self.view_class.as_view()(self.request, COURSE_ID, USAGE_KEY),
+            self.view_class.as_view()(self.request, COURSE_ID),
             logged_http_response_bad_request_mock(),
         )
         message_launch_mock.assert_called_once_with(
@@ -302,13 +270,120 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         gettext_mock.assert_called_once_with('LTI 1.3 Resource Link Launch: Error message')
         message_launch_mock.return_value.get_launch_data.assert_not_called()
         get_identity_claims_mock.assert_not_called()
+        get_resource_id_mock.assert_not_called()
+        get_opaque_keys_mock.assert_not_called()
+        validate_opaque_keys_mock.assert_not_called()
         check_course_access_permission_mock.assert_not_called()
         lti_profile_update_or_create_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
-        course_key_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
         handle_ags_mock.assert_not_called()
+
+
+class TestResourceLinkLaunchViewGetResourceId(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.get_resource_id method."""
+
+    def test_with_resource_id(self):
+        """Test method with resource_id argument."""
+        resource_id = 'resource-id-argument'
+
+        self.assertEqual(
+            self.view_class().get_resource_id(resource_id, {}),
+            resource_id,
+        )
+
+    def test_with_custom_parameter(self):
+        """Tets method with resource_id key in custom_parameters argument."""
+        resource_id = 'resource-id-custom-parameter'
+
+        self.assertEqual(
+            self.view_class().get_resource_id('', {'resourceId': resource_id}),
+            resource_id,
+        )
+
+
+@patch(f'{MODULE_PATH}.CourseKey')
+@patch(f'{MODULE_PATH}.UsageKey')
+class TestResourceLinkLaunchViewGetOpaqueKeys(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.get_opaque_keys method."""
+
+    def test_with_usage_key(
+        self,
+        usage_key_mock: MagicMock,
+        course_key_mock: MagicMock,
+    ):
+        """Test with a UsageKey in resource_id argument."""
+        course_key_mock.from_string.side_effect = InvalidKeyError(None, None)
+
+        self.assertEqual(
+            self.view_class().get_opaque_keys(self.resource_id),
+            (
+                usage_key_mock.from_string.return_value.course_key,
+                usage_key_mock.from_string.return_value,
+            ),
+        )
+
+        course_key_mock.from_string.assert_called_once_with(self.resource_id)
+        usage_key_mock.from_string.assert_called_once_with(self.resource_id)
+
+    def test_with_course_key(
+        self,
+        usage_key_mock: MagicMock,
+        course_key_mock: MagicMock,
+    ):
+        """Test with a CourseKey in resource_id argument."""
+        usage_key_mock.from_string.side_effect = InvalidKeyError(None, None)
+
+        self.assertEqual(
+            self.view_class().get_opaque_keys(self.resource_id),
+            (
+                course_key_mock.from_string.return_value,
+                None,
+            ),
+        )
+
+        course_key_mock.from_string.assert_called_once_with(self.resource_id)
+        usage_key_mock.from_string.assert_called_once_with(self.resource_id)
+
+
+@ddt.ddt
+@patch(f'{MODULE_PATH}._', return_value='')
+class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.validate_opaque_keys method."""
+
+    def test_with_course_key(self, gettext_mock: MagicMock):
+        """Test with course_key argument."""
+        self.assertIsNone(self.view_class().validate_opaque_keys(self.course_key, None, None))
+        gettext_mock.assert_not_called()
+
+    def test_without_course_key(self, gettext_mock: MagicMock):
+        """Test without course_key argument."""
+        with self.assertRaises(LtiToolLaunchException) as ctxm:
+            self.view_class().validate_opaque_keys(None, None, self.resource_id)
+
+        gettext_mock.assert_called_once_with(
+            f'CourseKey not found from resource ID: {self.resource_id}',
+        )
+        self.assertEqual(gettext_mock(), str(ctxm.exception))
+
+    def test_with_valid_usage_key(self, gettext_mock: MagicMock):
+        """Test with valid usage_key argument."""
+        self.assertIsNone(self.view_class().validate_opaque_keys(self.course_key, self.usage_key, ''))
+        gettext_mock.assert_not_called()
+
+    @ddt.data('chapter', 'sequential', 'course')
+    def test_with_invalid_usage_key(self, block_type: str, gettext_mock: MagicMock):
+        """Test with invalid usage_key argument."""
+        self.usage_key.block_type = block_type
+
+        with self.assertRaises(LtiToolLaunchException) as ctxm:
+            self.view_class().validate_opaque_keys(self.course_key, self.usage_key, '')
+
+        gettext_mock.assert_called_once_with(
+            f'Invalid UsageKey XBlock type: {self.usage_key.block_type}',
+        )
+        self.assertEqual(gettext_mock(), str(ctxm.exception))
 
 
 @patch(f'{MODULE_PATH}.COURSE_ACCESS_CONFIGURATION')
@@ -423,8 +498,8 @@ class TestResourceLinkLaunchViewAuthenticateAndLogin(ResourceLinkLaunchViewBaseT
         """Test with user."""
         authenticate_mock.return_value = self.user
 
-        self.assertEqual(self.view_class().authenticate_and_login(None, **LAUNCH_DATA), self.user)
-        authenticate_mock.assert_called_once_with(None, **LAUNCH_DATA)
+        self.assertEqual(self.view_class().authenticate_and_login(None, **IDENTITY_CLAIMS), self.user)
+        authenticate_mock.assert_called_once_with(None, **IDENTITY_CLAIMS)
         login_mock.assert_called_once_with(None, self.user)
         mark_user_change_as_expected_mock.assert_called_once_with(self.user.id)
 
@@ -438,12 +513,12 @@ class TestResourceLinkLaunchViewAuthenticateAndLogin(ResourceLinkLaunchViewBaseT
         authenticate_mock.return_value = None
 
         with self.assertRaises(LtiToolLaunchException) as ex:
-            self.view_class().authenticate_and_login(None, **LAUNCH_DATA)
+            self.view_class().authenticate_and_login(None, **IDENTITY_CLAIMS)
         self.assertEqual(
             str(ex.exception),
             'Profile authentication failed.',
         )
-        authenticate_mock.assert_called_once_with(None, **LAUNCH_DATA)
+        authenticate_mock.assert_called_once_with(None, **IDENTITY_CLAIMS)
         login_mock.assert_not_called()
         mark_user_change_as_expected_mock.assert_not_called()
 
@@ -489,39 +564,45 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
 class TestResourceLinkLaunchViewGetLaunchResponse(ResourceLinkLaunchViewBaseTestCase):
     """Test ResourceLinkLaunchView get_launch_response method."""
 
+    @patch(f'{MODULE_PATH}.redirect')
+    def test_with_usage_key(
+        self,
+        redirect_mock: MagicMock,
+        set_logged_in_cookies: MagicMock,
+    ):
+        """Test with usage_key."""
+        self.assertEqual(
+            self.view_class().get_launch_response(
+                None,
+                self.user,
+                self.course_key,
+                self.usage_key,
+            ),
+            set_logged_in_cookies.return_value,
+        )
+        redirect_mock.assert_called_once_with('render_xblock', str(self.usage_key.course_key))
+        set_logged_in_cookies.assert_called_once_with(None, redirect_mock(), self.user)
+
     @patch.object(ResourceLinkLaunchView, 'get_course_launch_response')
-    def test_with_course_launch(
+    def test_without_usage_key(
         self,
         get_course_launch_response_mock: MagicMock,
         set_logged_in_cookies: MagicMock,
     ):
-        """Test with course launch."""
+        """Test without usage_key."""
         self.assertEqual(
-            self.view_class().get_launch_response(None, self.user, COURSE_ID),
-            (set_logged_in_cookies.return_value, COURSE_ID),
+            self.view_class().get_launch_response(
+                None,
+                self.user,
+                self.course_key,
+                None,
+            ),
+            set_logged_in_cookies.return_value,
         )
-        get_course_launch_response_mock.assert_called_once_with(COURSE_ID)
+        get_course_launch_response_mock.assert_called_once_with(str(self.course_key))
         set_logged_in_cookies.assert_called_once_with(
             None,
             get_course_launch_response_mock(),
-            self.user,
-        )
-
-    @patch.object(ResourceLinkLaunchView, 'get_unit_component_launch_response')
-    def test_with_unit_or_component_launch(
-        self,
-        get_unit_component_launch_response_mock: MagicMock,
-        set_logged_in_cookies: MagicMock,
-    ):
-        """Test with unit or component launch."""
-        self.assertEqual(
-            self.view_class().get_launch_response(None, self.user, COURSE_ID, USAGE_KEY),
-            (set_logged_in_cookies.return_value, USAGE_KEY),
-        )
-        get_unit_component_launch_response_mock.assert_called_once_with(USAGE_KEY, COURSE_ID)
-        set_logged_in_cookies.assert_called_once_with(
-            None,
-            get_unit_component_launch_response_mock(),
             self.user,
         )
 
@@ -569,68 +650,6 @@ class TestResourceLinkLaunchViewGetCourseLaunchResponse(ResourceLinkLaunchViewBa
         allow_complete_course_launch_mock.is_enabled.assert_called_once_with()
         gettext_mock.assert_called_once_with('Complete course launches are not enabled.')
         configuration_helpers().get_value.assert_not_called()
-        redirect_mock.assert_not_called()
-
-
-@ddt
-@patch(f'{MODULE_PATH}.redirect')
-@patch(f'{MODULE_PATH}.UsageKey')
-class TestResourceLinkLaunchViewGetUnitComponentLaunchResponse(ResourceLinkLaunchViewBaseTestCase):
-    """Test ResourceLinkLaunchView get_course_launch_response method."""
-
-    @data('vertical', 'html')
-    def test_with_valid_usage_key(
-        self,
-        block_type: str,
-        usage_key_mock: MagicMock,
-        redirect_mock: MagicMock,
-    ):
-        """Test with valid usage key."""
-        usage_key_mock.from_string.return_value = MagicMock(
-            course_key=COURSE_ID,
-            block_type=block_type,
-        )
-
-        self.assertEqual(
-            self.view_class().get_unit_component_launch_response(USAGE_KEY, COURSE_ID),
-            redirect_mock.return_value,
-        )
-        usage_key_mock.from_string.assert_called_once_with(USAGE_KEY)
-        redirect_mock.assert_called_once_with('render_xblock', USAGE_KEY)
-
-    @patch(f'{MODULE_PATH}._')
-    def test_with_invalid_course_id(
-        self,
-        gettext_mock: MagicMock,
-        usage_key_mock: MagicMock,
-        redirect_mock: MagicMock,
-    ):
-        """Test with invalid course ID in usage key."""
-        usage_key_mock.from_string.return_value = MagicMock(course_key='different-course-id')
-
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().get_unit_component_launch_response(USAGE_KEY, COURSE_ID)
-        gettext_mock.assert_called_once_with('Unit/component does not belong to course.')
-        redirect_mock.assert_not_called()
-
-    @data('sequential', 'chapter', 'course')
-    @patch(f'{MODULE_PATH}._')
-    def test_with_invalid_usage_key(
-        self,
-        block_type: str,
-        gettext_mock: MagicMock,
-        usage_key_mock: MagicMock,
-        redirect_mock: MagicMock,
-    ):
-        """Test with invalid usage key."""
-        usage_key_mock.from_string.return_value = MagicMock(
-            course_key=COURSE_ID,
-            block_type=block_type,
-        )
-
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().get_unit_component_launch_response(USAGE_KEY, COURSE_ID)
-        gettext_mock.assert_called_once_with(f'Invalid XBlock type: {block_type}')
         redirect_mock.assert_not_called()
 
 

--- a/openedx_lti_tool_plugin/resource_link_launch/urls.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/urls.py
@@ -5,21 +5,20 @@ Attributes:
     urlpatterns (list): URL patterns list.
 
 """
-from django.conf import settings
-from django.urls import re_path
+from django.urls import path
 
 from openedx_lti_tool_plugin.resource_link_launch import views
 
 app_name = 'resource-link'
 urlpatterns = [
-    re_path(
-        fr'^{settings.COURSE_ID_PATTERN}$',
+    path(
+        '',
         views.ResourceLinkLaunchView.as_view(),
-        name='launch-course',
+        name='launch',
     ),
-    re_path(
-        fr'^{settings.COURSE_ID_PATTERN}/{settings.USAGE_KEY_PATTERN}$',
+    path(
+        '<str:resource_id>',
         views.ResourceLinkLaunchView.as_view(),
-        name='launch-usage-key',
+        name='launch-resource-id',
     ),
 ]


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2053

## Description

This PR improves the resource ID handling on ResourceLinkLaunchView and the Deep Linking workflow. Currently ResourceLinkLaunchView determines the requested resource by obtaining the course ID and/or the usage key of a unit/component from the URL pattern of this view, this PR improves these by making the URL pattern receive a single resource ID that can either be a course ID or usage key, this can be optional since the resource ID can also be retrieved from the `resource_id` key value from the LTI custom parameters. The Deep Linking workflow was also updated to include the resource ID on the content item custom parameters instead of including it on the URL path. This was created to make an easier integration with the Deep Linking service and the redirect URI(s) field that is setup on the LTI platform.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Install `openedx_lti_tool_plugin` on the LMS.
3. Run ngrok or any other similar service on LMS: `ngrok http 18000`
4. Add required settings to LMS.
	
```python
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

5. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
6. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

7. Restart the LMS: `make dev.restart-container.lms`.
8. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

9. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

10. Create a new LTI 1.3 tool key config: https://lms.ngrok.io/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
11. Create a new LTI 1.3 tool config: https://lms.ngrok.io/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

12. Go to the saLTIre platform https://saltire.lti.app/platform
13. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/deep_linking/
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/deep_linking/
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

14. Go to "Message" on the left sidebar and set these settings:

```
Message type: LtiDeepLinkingRequest
```

15. Click on the "Save" button on the top navbar.
16. Click on the dropdown next to the "Connect" button on the top navbar.
17. Click on "Open in iframe".
18. You should be redirected to the Deep Linking Form View.
19. Select one or more rows from the table.
20. Click on the "Submit" button.
21. The browser should be redirected back to saLTIre,
22. The "Sumary" section should show "Verification: Passed" and the "JWT" section should contain the content items from the selected rows in the table.
23. The content items should contain a custom parameter named `resource_id` with the requested course ID.
24. Go to "Message" on the left sidebar and set these settings:

```
Message type: LtiResourceLinkRequest
Custom parameters: resource_id={course_id}
```

25. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

26. Click on the "Save" button on the top navbar.
27. Click on the dropdown next to the "Connect" button on the top navbar.
28. Click on "Open in iframe".
29. You should be redirected to the learning MFE with the requested course.