### PR TITLE
PADV-2211: Improve LtiProfile admin configuration

### DIFF
--- a/openedx_lti_tool_plugin/admin.py
+++ b/openedx_lti_tool_plugin/admin.py
@@ -1,4 +1,4 @@
-"""Admin configuration for openedx_lti_tool_plugin."""
+"""Django Admin."""
 from django.contrib import admin
 
 from openedx_lti_tool_plugin.models import LtiProfile, LtiToolConfiguration
@@ -6,10 +6,55 @@ from openedx_lti_tool_plugin.models import LtiProfile, LtiToolConfiguration
 
 @admin.register(LtiProfile)
 class LtiProfileAdmin(admin.ModelAdmin):
-    """Admin configuration for LtiProfile model."""
+    """LtiProfile admin configuration."""
 
-    list_display = ('id', 'uuid', 'platform_id', 'client_id', 'subject_id')
-    search_fields = ['id', 'uuid', 'platform_id', 'client_id', 'subject_id']
+    readonly_fields = [
+        'uuid',
+        'user',
+    ]
+    list_display = (
+        'id',
+        'uuid',
+        'platform_id',
+        'client_id',
+        'subject_id',
+        'user_id',
+        'user_email',
+    )
+    search_fields = [
+        'id',
+        'uuid',
+        'platform_id',
+        'client_id',
+        'subject_id',
+        'user__email',
+    ]
+
+    @admin.display(description='User ID')
+    def user_id(self, instance: LtiProfile) -> str:
+        """User ID list_display method.
+
+        Args:
+            instance: LtiProfile instance.
+
+        Returns:
+            User ID.
+
+        """
+        return instance.user.id
+
+    @admin.display(description='User email')
+    def user_email(self, instance: LtiProfile) -> str:
+        """User email list_display method.
+
+        Args:
+            instance: LtiProfile instance.
+
+        Returns:
+            User email.
+
+        """
+        return instance.user.email
 
 
 @admin.register(LtiToolConfiguration)

--- a/openedx_lti_tool_plugin/tests/test_admin.py
+++ b/openedx_lti_tool_plugin/tests/test_admin.py
@@ -1,4 +1,4 @@
-"""Tests for the openedx_lti_tool_plugin admin module."""
+"""Test admin module."""
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -10,19 +10,66 @@ from openedx_lti_tool_plugin.tests import AUD, ISS, SUB
 
 
 class TestLtiProfileAdmin(TestCase):
-    """Test LTI 1.3 profile admin functionality."""
+    """Test LtiProfileAdmin admin configuration."""
 
     def setUp(self):
-        """Test fixtures setup."""
+        """Set up test fixtures."""
         self.admin = LtiProfileAdmin(LtiProfile, AdminSite)
-        self.user = get_user_model().objects.create_superuser(username='x', password='x', email='x@example.com')
+        self.user = get_user_model().objects.create_superuser(
+            username='test-username',
+            email='test@example.com',
+        )
         self.client.force_login(self.user)
-        self.profile = LtiProfile.objects.create(platform_id=ISS, client_id=AUD, subject_id=SUB)
+        self.lti_profile = LtiProfile.objects.create(
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+        )
 
     def test_instance_attributes(self):
         """Test instance attributes."""
-        self.assertEqual(self.admin.list_display, ('id', 'uuid', 'platform_id', 'client_id', 'subject_id'))
-        self.assertEqual(self.admin.search_fields, ['id', 'uuid', 'platform_id', 'client_id', 'subject_id'])
+        self.assertEqual(
+            self.admin.readonly_fields, [
+                'uuid',
+                'user',
+            ],
+        )
+        self.assertEqual(
+            self.admin.list_display,
+            (
+                'id',
+                'uuid',
+                'platform_id',
+                'client_id',
+                'subject_id',
+                'user_id',
+                'user_email',
+            ),
+        )
+        self.assertEqual(
+            self.admin.search_fields, [
+                'id',
+                'uuid',
+                'platform_id',
+                'client_id',
+                'subject_id',
+                'user__email',
+            ],
+        )
+
+    def test_user_id(self):
+        """Test user_id method."""
+        self.assertEqual(
+            self.admin.user_id(self.lti_profile),
+            self.lti_profile.user.id,
+        )
+
+    def test_user_email(self):
+        """Test user_email method."""
+        self.assertEqual(
+            self.admin.user_email(self.lti_profile),
+            self.lti_profile.user.email,
+        )
 
 
 class TestLtiToolConfigurationAdmin(TestCase):


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2211

## Description

This PR improves the Django admin configuration of the LtiProfile. This PR adds the user ID and user email to the list columns, adds the user email to the search fields and additionally adds the LtiProfile uuid and user had read-only fields while editing an LtiProfile.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Go to http://localhost:18000/admin/openedx_lti_tool_plugin/ltiprofile
3. Verify the user ID and user email are present on the list columns.
4. Verify the Django admin can search using the LtiProfile user email.
5. Verify the uuid and user are shown while modifying an LtiProfile.
