### PR TITLE
PADV-2213: Add ResourceLinkLaunchView user provisioning mode feature

### DIFF
--- a/openedx_lti_tool_plugin/deep_linking/exceptions.py
+++ b/openedx_lti_tool_plugin/deep_linking/exceptions.py
@@ -1,5 +1,6 @@
 """Exceptions."""
+from openedx_lti_tool_plugin.exceptions import LtiToolException
 
 
-class DeepLinkingException(Exception):
+class DeepLinkingException(LtiToolException):
     """A exception for Deep Linking errors."""

--- a/openedx_lti_tool_plugin/deep_linking/views.py
+++ b/openedx_lti_tool_plugin/deep_linking/views.py
@@ -10,7 +10,6 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
-from pylti1p3.contrib.django import DjangoMessageLaunch
 from pylti1p3.exception import LtiException
 
 from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
@@ -53,11 +52,7 @@ class DeepLinkingView(LTIToolView):
         """
         try:
             # Get launch message.
-            message = DjangoMessageLaunch(
-                request,
-                self.tool_config,
-                launch_data_storage=self.tool_storage,
-            )
+            message = self.get_message(request)
             # Check launch message type.
             validate_deep_linking_message(message)
             # Redirect to DeepLinkingForm view.

--- a/openedx_lti_tool_plugin/exceptions.py
+++ b/openedx_lti_tool_plugin/exceptions.py
@@ -1,0 +1,5 @@
+"""Exceptions."""
+
+
+class LtiToolException(Exception):
+    """An exception for LTI tool errors."""

--- a/openedx_lti_tool_plugin/mixins.py
+++ b/openedx_lti_tool_plugin/mixins.py
@@ -1,6 +1,5 @@
 """Mixins."""
 from typing import Union
-from uuid import uuid4
 
 from django.http.request import HttpRequest
 from django.utils.translation import gettext as _
@@ -40,12 +39,31 @@ class LTIToolMixin:
         self.tool_config = DjangoDbToolConf()
         self.tool_storage = DjangoCacheDataStorage(cache_name='default')
 
+    def get_message(
+        self,
+        request: HttpRequest,
+    ) -> DjangoMessageLaunch:
+        """Get DjangoMessageLaunch.
+
+        Args:
+            request: HTTP request object.
+
+        Returns:
+            DjangoMessageLaunch object.
+
+        """
+        return DjangoMessageLaunch(
+            request,
+            self.tool_config,
+            launch_data_storage=self.tool_storage,
+        )
+
     def get_message_from_cache(
         self,
         request: HttpRequest,
-        launch_id: uuid4,
+        launch_id: str,
     ) -> DjangoMessageLaunch:
-        """Get DjangoMessageLaunch from Django cache data storage.
+        """Get DjangoMessageLaunch from cache.
 
         Args:
             request: HTTP request object.

--- a/openedx_lti_tool_plugin/models.py
+++ b/openedx_lti_tool_plugin/models.py
@@ -407,6 +407,29 @@ class LtiToolConfiguration(models.Model):
         """
         return course_id in json.loads(self.allowed_course_ids)
 
+    def allows_linking_user(self) -> bool:
+        """Check if instance allows linking User to LtiProfile.
+
+        Returns:
+            True if linking User is allowed.
+            False if linking User is not allowed.
+
+        """
+        return self.user_provisioning_mode in [
+            self.UserProvisioningMode.EXISTING_ONLY,
+            self.UserProvisioningMode.EXISTING_AND_NEW,
+        ]
+
+    def requires_linking_user(self) -> bool:
+        """Check if instance requires linking User to LtiProfile.
+
+        Returns:
+            True if linking User is required.
+            False if linking User is not required.
+
+        """
+        return self.user_provisioning_mode == self.UserProvisioningMode.EXISTING_ONLY
+
     def __str__(self) -> str:
         """Get a string representation of this model instance."""
         return f'<LtiToolConfiguration, ID: {self.id}>'

--- a/openedx_lti_tool_plugin/resource_link_launch/exceptions.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/exceptions.py
@@ -1,5 +1,6 @@
 """Exceptions."""
+from openedx_lti_tool_plugin.exceptions import LtiToolException
 
 
-class LtiToolLaunchException(Exception):
-    """A exception for LTI launch view errors."""
+class ResourceLinkException(LtiToolException):
+    """An exception for resource link errors."""

--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_utils.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_utils.py
@@ -1,0 +1,42 @@
+"""Tests utils module."""
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from openedx_lti_tool_plugin.resource_link_launch.exceptions import ResourceLinkException
+from openedx_lti_tool_plugin.resource_link_launch.tests import MODULE_PATH
+from openedx_lti_tool_plugin.resource_link_launch.utils import validate_resource_link_message
+
+MODULE_PATH = f'{MODULE_PATH}.utils'
+
+
+class TestValidateResourceLinkMessage(TestCase):
+    """Test validate_resource_link_message function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.message = MagicMock()
+
+    def test_with_deep_linking_message(self: MagicMock):
+        """Test with LtiResourceLinkRequest message (happy path)."""
+        self.message.is_resource_launch.return_value = True
+
+        validate_resource_link_message(self.message)
+
+        self.message.is_resource_launch.assert_called_once_with()
+
+    @patch(f'{MODULE_PATH}._', return_value='')
+    def test_without_deep_linking_message(
+        self: MagicMock,
+        gettext_mock: MagicMock,
+    ):
+        """Test without LtiResourceLinkRequest message."""
+        self.message.is_resource_launch.return_value = False
+
+        with self.assertRaises(ResourceLinkException) as ctxm:
+            validate_resource_link_message(self.message)
+
+        self.message.is_resource_launch.assert_called_once_with()
+        gettext_mock.assert_called_once_with('Message type is not LtiResourceLinkRequest.')
+        self.assertEqual(gettext_mock(), str(ctxm.exception))

--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
@@ -1,5 +1,5 @@
 """Tests views module."""
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import ddt
 from django.conf import settings
@@ -10,8 +10,8 @@ from opaque_keys import InvalidKeyError
 from pylti1p3.exception import LtiException
 
 from openedx_lti_tool_plugin.edxapp_wrapper.student_module import course_enrollment_exception
-from openedx_lti_tool_plugin.models import LtiProfile
-from openedx_lti_tool_plugin.resource_link_launch.exceptions import LtiToolLaunchException
+from openedx_lti_tool_plugin.models import LtiProfile, LtiToolConfiguration
+from openedx_lti_tool_plugin.resource_link_launch.exceptions import ResourceLinkException
 from openedx_lti_tool_plugin.resource_link_launch.tests import MODULE_PATH
 from openedx_lti_tool_plugin.resource_link_launch.views import (
     AGS_CLAIM_ENDPOINT,
@@ -28,6 +28,7 @@ CUSTOM_PARAMETERS = {'x': 'x'}
 LAUNCH_DATA = {**IDENTITY_CLAIMS, CUSTOM_CLAIM: CUSTOM_PARAMETERS}
 LTI_PROFILE = 'random-lti-profile'
 PII = {'x': 'x'}
+LAUNCH_ID = 'test-launch-id'
 
 
 class ResourceLinkLaunchViewBaseTestCase(TestCase):
@@ -42,18 +43,38 @@ class ResourceLinkLaunchViewBaseTestCase(TestCase):
         self.course_key = MagicMock()
         self.usage_key = MagicMock()
         self.resource_id = 'test-resource-id'
+        self.message = MagicMock()
+        self.lti_tool_configuration = MagicMock()
 
 
-@ddt.ddt
-@patch.object(ResourceLinkLaunchView, 'tool_config', new_callable=PropertyMock)
-@patch.object(ResourceLinkLaunchView, 'tool_storage', new_callable=PropertyMock)
-@patch(f'{MODULE_PATH}.DjangoMessageLaunch')
+@patch.object(ResourceLinkLaunchView, 'post')
+class TestResourceLinkLaunchViewGet(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.get method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.request = MagicMock()
+
+    def test_with_request(self, post_mock: MagicMock):
+        """Test with request."""
+        self.assertEqual(
+            self.view_class().get(self.request),
+            post_mock.return_value,
+        )
+        post_mock.assert_called_once_with(self.request)
+
+
+@patch.object(ResourceLinkLaunchView, 'try_get_message')
+@patch(f'{MODULE_PATH}.validate_resource_link_message')
 @patch.object(ResourceLinkLaunchView, 'get_resource_id')
 @patch.object(ResourceLinkLaunchView, 'get_opaque_keys')
 @patch.object(ResourceLinkLaunchView, 'validate_opaque_keys')
 @patch(f'{MODULE_PATH}.get_identity_claims')
+@patch.object(ResourceLinkLaunchView, 'get_lti_tool_configuration')
 @patch.object(ResourceLinkLaunchView, 'check_course_access_permission')
-@patch.object(LtiProfile.objects, 'update_or_create', return_value=(LTI_PROFILE, None))
+@patch.object(ResourceLinkLaunchView, 'get_or_create_lti_profile')
+@patch.object(ResourceLinkLaunchView, 'render_login_prompt')
 @patch.object(ResourceLinkLaunchView, 'authenticate_and_login')
 @patch.object(ResourceLinkLaunchView, 'enroll')
 @patch.object(ResourceLinkLaunchView, 'get_launch_response', return_value=(MagicMock(), COURSE_KEY))
@@ -69,37 +90,36 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         self.request.user = self.user
         self.enrollment_mock = MagicMock()
 
-    def test_with_resource_id(
+    def test_with_lti_profile(
         self,
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
-        lti_profile_update_or_create_mock: MagicMock,
+        render_login_prompt_mock: MagicMock,
+        get_or_create_lti_profile_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
+        get_lti_tool_configuration_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
         validate_opaque_keys_mock: MagicMock,
         get_opaque_keys_mock: MagicMock,
         get_resource_id_mock: MagicMock,
-        message_launch_mock: MagicMock,
-        tool_storage_mock: MagicMock,
-        tool_conf_mock: MagicMock,
+        validate_resource_link_message_mock: MagicMock,
+        try_get_message_mock: MagicMock,
     ):
-        """Test with resource_id."""
-        message_launch_mock.return_value.get_launch_data.return_value = LAUNCH_DATA
+        """Test with LtiProfle."""
+        try_get_message_mock.return_value.get_launch_data.return_value = LAUNCH_DATA
         get_opaque_keys_mock.return_value = (self.course_key, self.usage_key)
         get_identity_claims_mock.return_value = (ISS, AUD, SUB, PII)
         get_launch_response_mock.return_value = MagicMock()
 
-        response = self.view_class.as_view()(self.request, COURSE_ID)
-
-        message_launch_mock.assert_called_once_with(
-            self.request,
-            tool_conf_mock(),
-            launch_data_storage=tool_storage_mock(),
+        self.assertEqual(
+            self.view_class.as_view()(self.request, COURSE_ID),
+            get_launch_response_mock.return_value,
         )
-        message_launch_mock().is_resource_launch.assert_called_once_with()
-        message_launch_mock().get_launch_data.assert_called_once_with()
+        try_get_message_mock.assert_called_once_with(self.request)
+        validate_resource_link_message_mock.assert_called_once_with(try_get_message_mock())
+        try_get_message_mock().get_launch_data.assert_called_once_with()
         get_resource_id_mock.assert_called_once_with(COURSE_ID, CUSTOM_PARAMETERS)
         get_opaque_keys_mock.assert_called_once_with(get_resource_id_mock())
         validate_opaque_keys_mock.assert_called_once_with(
@@ -108,19 +128,22 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
             get_resource_id_mock(),
         )
         get_identity_claims_mock.assert_called_once_with(
-            message_launch_mock().get_launch_data(),
+            try_get_message_mock().get_launch_data(),
         )
+        get_lti_tool_configuration_mock.assert_called_once_with(ISS, AUD)
         check_course_access_permission_mock.assert_called_once_with(
             str(self.course_key),
+            get_lti_tool_configuration_mock(),
+        )
+        get_or_create_lti_profile_mock.assert_called_once_with(
+            self.request,
             ISS,
             AUD,
+            SUB,
+            PII,
+            get_lti_tool_configuration_mock(),
         )
-        lti_profile_update_or_create_mock.assert_called_once_with(
-            platform_id=ISS,
-            client_id=AUD,
-            subject_id=SUB,
-            defaults={'pii': PII},
-        )
+        render_login_prompt_mock.assert_not_called()
         authenticate_and_login_mock.assert_called_once_with(self.request, ISS, AUD, SUB)
         enroll_mock.assert_called_once_with(
             self.request,
@@ -134,57 +157,70 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
             self.usage_key,
         )
         handle_ags_mock.assert_called_once_with(
-            message_launch_mock(),
-            message_launch_mock().get_launch_data(),
-            lti_profile_update_or_create_mock()[0],
+            try_get_message_mock(),
+            try_get_message_mock().get_launch_data(),
+            get_or_create_lti_profile_mock(),
             get_resource_id_mock(),
         )
-        self.assertEqual(response, get_launch_response_mock())
 
-    @patch(f'{MODULE_PATH}._')
-    def test_without_resource_link_launch(
+    def test_without_lti_profile(
         self,
-        gettext_mock: MagicMock,
         handle_ags_mock: MagicMock,
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
-        lti_profile_update_or_create_mock: MagicMock,
+        render_login_prompt_mock: MagicMock,
+        get_or_create_lti_profile_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
+        get_lti_tool_configuration_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
         validate_opaque_keys_mock: MagicMock,
         get_opaque_keys_mock: MagicMock,
         get_resource_id_mock: MagicMock,
-        message_launch_mock: MagicMock,
-        tool_storage_mock: MagicMock,
-        tool_conf_mock: MagicMock,
+        validate_resource_link_message_mock: MagicMock,
+        try_get_message_mock: MagicMock,
     ):
-        """Test without a resource link launch message type."""
-        message_launch_mock.return_value.is_resource_launch.return_value = False
+        """Test without LtiProfle."""
+        try_get_message_mock.return_value.get_launch_data.return_value = LAUNCH_DATA
+        get_opaque_keys_mock.return_value = (self.course_key, self.usage_key)
+        get_identity_claims_mock.return_value = (ISS, AUD, SUB, PII)
+        get_or_create_lti_profile_mock.return_value = None
 
-        response = self.view_class.as_view()(self.request, COURSE_ID)
-
-        self.assertEqual(response.status_code, 400)
-        message_launch_mock.assert_called_once_with(
+        self.assertEqual(
+            self.view_class.as_view()(self.request, COURSE_ID),
+            render_login_prompt_mock.return_value,
+        )
+        try_get_message_mock.assert_called_once_with(self.request)
+        validate_resource_link_message_mock.assert_called_once_with(try_get_message_mock())
+        try_get_message_mock().get_launch_data.assert_called_once_with()
+        get_resource_id_mock.assert_called_once_with(COURSE_ID, CUSTOM_PARAMETERS)
+        get_opaque_keys_mock.assert_called_once_with(get_resource_id_mock())
+        validate_opaque_keys_mock.assert_called_once_with(
+            self.course_key,
+            self.usage_key,
+            get_resource_id_mock(),
+        )
+        get_identity_claims_mock.assert_called_once_with(
+            try_get_message_mock().get_launch_data(),
+        )
+        get_lti_tool_configuration_mock.assert_called_once_with(ISS, AUD)
+        check_course_access_permission_mock.assert_called_once_with(
+            str(self.course_key),
+            get_lti_tool_configuration_mock(),
+        )
+        get_or_create_lti_profile_mock.assert_called_once_with(
             self.request,
-            tool_conf_mock(),
-            launch_data_storage=tool_storage_mock(),
+            ISS,
+            AUD,
+            SUB,
+            PII,
+            get_lti_tool_configuration_mock(),
         )
-        message_launch_mock().is_resource_launch.assert_called_once_with()
-        gettext_mock.assert_has_calls(
-            [
-                call('Message type is not LtiResourceLinkRequest.'),
-                call(f'LTI 1.3 Resource Link Launch: {gettext_mock.return_value}'),
-            ],
-            any_order=True,
+        render_login_prompt_mock.assert_called_once_with(
+            self.request,
+            try_get_message_mock(),
+            get_lti_tool_configuration_mock(),
         )
-        message_launch_mock().get_launch_data.assert_not_called()
-        get_resource_id_mock.assert_not_called()
-        get_opaque_keys_mock.assert_not_called()
-        validate_opaque_keys_mock.assert_not_called()
-        get_identity_claims_mock.assert_not_called()
-        check_course_access_permission_mock.assert_not_called()
-        lti_profile_update_or_create_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
@@ -200,44 +236,46 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
-        lti_profile_update_or_create_mock: MagicMock,
+        render_login_prompt_mock: MagicMock,
+        get_or_create_lti_profile_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
+        get_lti_tool_configuration_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
         validate_opaque_keys_mock: MagicMock,
         get_opaque_keys_mock: MagicMock,
         get_resource_id_mock: MagicMock,
-        message_launch_mock: MagicMock,
-        tool_storage_mock: MagicMock,
-        tool_conf_mock: MagicMock,
+        validate_resource_link_message_mock: MagicMock,
+        try_get_message_mock: MagicMock,
     ):
         """Test with LtiException."""
-        message_launch_mock.side_effect = LtiException('Error message')
+        error_message = 'Error message'
+        try_get_message_mock.side_effect = LtiException(error_message)
 
         self.assertEqual(
             self.view_class.as_view()(self.request, COURSE_ID),
-            logged_http_response_bad_request_mock(),
+            logged_http_response_bad_request_mock.return_value,
         )
-        message_launch_mock.assert_called_once_with(
-            self.request,
-            tool_conf_mock(),
-            launch_data_storage=tool_storage_mock(),
-        )
-        gettext_mock.assert_called_once_with('LTI 1.3 Resource Link Launch: Error message')
-        message_launch_mock.return_value.get_launch_data.assert_not_called()
+        try_get_message_mock.assert_called_once_with(self.request)
+        validate_resource_link_message_mock.assert_not_called()
+        try_get_message_mock.return_value.get_launch_data.assert_not_called()
         get_resource_id_mock.assert_not_called()
         get_opaque_keys_mock.assert_not_called()
         validate_opaque_keys_mock.assert_not_called()
         get_identity_claims_mock.assert_not_called()
+        get_lti_tool_configuration_mock.assert_not_called()
         check_course_access_permission_mock.assert_not_called()
-        lti_profile_update_or_create_mock.assert_not_called()
+        get_or_create_lti_profile_mock.assert_not_called()
+        render_login_prompt_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
         handle_ags_mock.assert_not_called()
+        gettext_mock.assert_called_once_with(f'LTI 1.3 Resource Link Launch: {error_message}')
+        logged_http_response_bad_request_mock.assert_called_once_with(gettext_mock())
 
     @patch(f'{MODULE_PATH}.LoggedHttpResponseBadRequest')
     @patch(f'{MODULE_PATH}._')
-    def test_with_lti_tool_launch_exception(
+    def test_with_resource_link_exception(
         self,
         gettext_mock: MagicMock,
         logged_http_response_bad_request_mock: MagicMock,
@@ -245,40 +283,87 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         get_launch_response_mock: MagicMock,
         enroll_mock: MagicMock,
         authenticate_and_login_mock: MagicMock,
-        lti_profile_update_or_create_mock: MagicMock,
+        render_login_prompt_mock: MagicMock,
+        get_or_create_lti_profile_mock: MagicMock,
         check_course_access_permission_mock: MagicMock,
+        get_lti_tool_configuration_mock: MagicMock,
         get_identity_claims_mock: MagicMock,
         validate_opaque_keys_mock: MagicMock,
         get_opaque_keys_mock: MagicMock,
         get_resource_id_mock: MagicMock,
-        message_launch_mock: MagicMock,
-        tool_storage_mock: MagicMock,
-        tool_conf_mock: MagicMock,
+        validate_resource_link_message_mock: MagicMock,
+        try_get_message_mock: MagicMock,
     ):
-        """Test with LtiToolLaunchException."""
-        message_launch_mock.side_effect = LtiToolLaunchException('Error message')
+        """Test with ResourceLinkException."""
+        error_message = 'Error message'
+        try_get_message_mock.side_effect = ResourceLinkException(error_message)
 
         self.assertEqual(
             self.view_class.as_view()(self.request, COURSE_ID),
-            logged_http_response_bad_request_mock(),
+            logged_http_response_bad_request_mock.return_value,
         )
-        message_launch_mock.assert_called_once_with(
-            self.request,
-            tool_conf_mock(),
-            launch_data_storage=tool_storage_mock(),
-        )
-        gettext_mock.assert_called_once_with('LTI 1.3 Resource Link Launch: Error message')
-        message_launch_mock.return_value.get_launch_data.assert_not_called()
-        get_identity_claims_mock.assert_not_called()
+        try_get_message_mock.assert_called_once_with(self.request)
+        validate_resource_link_message_mock.assert_not_called()
+        try_get_message_mock.return_value.get_launch_data.assert_not_called()
         get_resource_id_mock.assert_not_called()
         get_opaque_keys_mock.assert_not_called()
         validate_opaque_keys_mock.assert_not_called()
+        get_identity_claims_mock.assert_not_called()
+        get_lti_tool_configuration_mock.assert_not_called()
         check_course_access_permission_mock.assert_not_called()
-        lti_profile_update_or_create_mock.assert_not_called()
+        get_or_create_lti_profile_mock.assert_not_called()
+        render_login_prompt_mock.assert_not_called()
         authenticate_and_login_mock.assert_not_called()
         enroll_mock.assert_not_called()
         get_launch_response_mock.assert_not_called()
         handle_ags_mock.assert_not_called()
+        gettext_mock.assert_called_once_with(f'LTI 1.3 Resource Link Launch: {error_message}')
+        logged_http_response_bad_request_mock.assert_called_once_with(gettext_mock())
+
+
+@patch.object(ResourceLinkLaunchView, 'get_message')
+@patch.object(ResourceLinkLaunchView, 'get_message_from_cache')
+class TestResourceLinkLaunchViewTryGetMessage(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.try_get_message method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.request = MagicMock(GET={'launch_id': LAUNCH_ID})
+
+    def test_with_message_in_cache(
+        self,
+        get_message_from_cache_mock: MagicMock,
+        get_message_mock: MagicMock,
+    ):
+        """Test with DjangoMessageLaunch in cache."""
+        self.assertEqual(
+            self.view_class().try_get_message(self.request),
+            get_message_from_cache_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(
+            self.request,
+            LAUNCH_ID,
+        )
+        get_message_mock.assert_not_called()
+
+    def test_without_message_in_cache(
+        self,
+        get_message_from_cache_mock: MagicMock,
+        get_message_mock: MagicMock,
+    ):
+        """Test without DjangoMessageLaunch in cache."""
+        get_message_from_cache_mock.side_effect = LtiException
+
+        self.assertEqual(
+            self.view_class().try_get_message(self.request),
+            get_message_mock.return_value,
+        )
+        get_message_from_cache_mock.assert_called_once_with(
+            self.request,
+            LAUNCH_ID,
+        )
+        get_message_mock.assert_called_with(self.request)
 
 
 class TestResourceLinkLaunchViewGetResourceId(ResourceLinkLaunchViewBaseTestCase):
@@ -354,13 +439,13 @@ class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTes
 
     def test_with_course_key(self, gettext_mock: MagicMock):
         """Test with course_key argument."""
-        self.assertIsNone(self.view_class().validate_opaque_keys(self.course_key, None, None))
+        self.assertIsNone(self.view_class.validate_opaque_keys(self.course_key, None, None))
         gettext_mock.assert_not_called()
 
     def test_without_course_key(self, gettext_mock: MagicMock):
         """Test without course_key argument."""
-        with self.assertRaises(LtiToolLaunchException) as ctxm:
-            self.view_class().validate_opaque_keys(None, None, self.resource_id)
+        with self.assertRaises(ResourceLinkException) as ctxm:
+            self.view_class.validate_opaque_keys(None, None, self.resource_id)
 
         gettext_mock.assert_called_once_with(
             f'CourseKey not found from resource ID: {self.resource_id}',
@@ -369,7 +454,7 @@ class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTes
 
     def test_with_valid_usage_key(self, gettext_mock: MagicMock):
         """Test with valid usage_key argument."""
-        self.assertIsNone(self.view_class().validate_opaque_keys(self.course_key, self.usage_key, ''))
+        self.assertIsNone(self.view_class.validate_opaque_keys(self.course_key, self.usage_key, ''))
         gettext_mock.assert_not_called()
 
     @ddt.data('chapter', 'sequential', 'course')
@@ -377,8 +462,8 @@ class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTes
         """Test with invalid usage_key argument."""
         self.usage_key.block_type = block_type
 
-        with self.assertRaises(LtiToolLaunchException) as ctxm:
-            self.view_class().validate_opaque_keys(self.course_key, self.usage_key, '')
+        with self.assertRaises(ResourceLinkException) as ctxm:
+            self.view_class.validate_opaque_keys(self.course_key, self.usage_key, '')
 
         gettext_mock.assert_called_once_with(
             f'Invalid UsageKey XBlock type: {self.usage_key.block_type}',
@@ -386,100 +471,306 @@ class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTes
         self.assertEqual(gettext_mock(), str(ctxm.exception))
 
 
-@patch(f'{MODULE_PATH}.COURSE_ACCESS_CONFIGURATION')
 @patch.object(ResourceLinkLaunchView, 'tool_config', new_callable=PropertyMock)
-@patch(f'{MODULE_PATH}.LtiToolConfiguration')
+@patch.object(LtiToolConfiguration.objects, 'get')
+class TestResourceLinkLaunchViewGetLtiToolConfiguration(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.get_lti_tool_configuration method."""
+
+    def test_with_lti_tool_configuration(
+        self,
+        lti_tool_configuration_get_mock: MagicMock,
+        tool_config_mock: MagicMock,
+    ):
+        """Test with existing LtiToolConfiguration."""
+        self.assertEqual(
+            self.view_class().get_lti_tool_configuration(ISS, AUD),
+            lti_tool_configuration_get_mock.return_value,
+        )
+        tool_config_mock().get_lti_tool.assert_called_once_with(ISS, AUD)
+        lti_tool_configuration_get_mock.assert_called_once_with(
+            lti_tool=tool_config_mock().get_lti_tool(),
+        )
+
+    @patch(f'{MODULE_PATH}._', return_value='')
+    def test_without_lti_tool_configuration(
+        self,
+        gettext_mock: MagicMock,
+        lti_tool_configuration_get_mock: MagicMock,
+        tool_config_mock: MagicMock,
+    ):
+        """Test without existing LtiToolConfiguration."""
+        lti_tool_configuration_get_mock.side_effect = LtiToolConfiguration.DoesNotExist
+        iss = ISS
+        aud = AUD
+
+        with self.assertRaises(ResourceLinkException) as ctxm:
+            self.view_class().get_lti_tool_configuration(ISS, AUD)
+
+        tool_config_mock().get_lti_tool.assert_called_once_with(ISS, AUD)
+        lti_tool_configuration_get_mock.assert_called_once_with(
+            lti_tool=tool_config_mock().get_lti_tool(),
+        )
+        gettext_mock.assert_called_once_with(
+            f'LtiToolConfiguration not found: {iss=} and {aud=}',
+        )
+        self.assertEqual(gettext_mock(), str(ctxm.exception))
+
+
+@patch(f'{MODULE_PATH}.COURSE_ACCESS_CONFIGURATION')
 class TestResourceLinkLaunchViewCheckCourseAccessPermission(ResourceLinkLaunchViewBaseTestCase):
     """Test ResourceLinkLaunchView.check_course_access_permission method."""
 
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.lti_tool_configuration = MagicMock()
+
     def test_with_allowed_course_id(
         self,
-        lti_tool_configuration_mock: MagicMock,
-        tool_config_mock: MagicMock,
         course_access_configuration_switch_mock: MagicMock,
     ):
-        """Test with allowed course ID."""
-        course_access_configuration_switch_mock.is_enabled.return_value = True
-        course_access_conf_queryset_mock = (
-            lti_tool_configuration_mock.objects
-            .filter.return_value
-            .first.return_value
-        )
-        course_access_conf_queryset_mock.is_course_id_allowed.return_value = True
-
-        self.view_class().check_course_access_permission(COURSE_ID, ISS, AUD)
+        """Test with allowed Course ID."""
+        self.view_class.check_course_access_permission(COURSE_ID, self.lti_tool_configuration)
 
         course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
-        tool_config_mock().get_lti_tool.assert_called_once_with(ISS, AUD)
-        lti_tool_configuration_mock.objects.filter.assert_called_once_with(
-            lti_tool=tool_config_mock().get_lti_tool(),
-        )
-        lti_tool_configuration_mock.objects.filter.return_value.first.assert_called_once_with()
-        course_access_conf_queryset_mock.is_course_id_allowed.assert_called_once_with(COURSE_ID)
+        self.lti_tool_configuration.is_course_id_allowed.assert_called_once_with(COURSE_ID)
 
     def test_with_disabled_course_access_configuration_switch(
         self,
-        lti_tool_configuration_mock: MagicMock,
-        tool_config_mock: MagicMock,
         course_access_configuration_switch_mock: MagicMock,
     ):
         """Test with disabled `COURSE_ACCESS_CONFIGURATION` switch."""
         course_access_configuration_switch_mock.is_enabled.return_value = False
-        course_access_conf_queryset_mock = (
-            lti_tool_configuration_mock.objects
-            .filter.return_value
-            .first.return_value
-        )
 
-        self.view_class().check_course_access_permission(COURSE_ID, ISS, AUD)
+        self.view_class.check_course_access_permission(
+            COURSE_ID,
+            self.lti_tool_configuration,
+        )
 
         course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
-        tool_config_mock.get_lti_tool.assert_not_called()
-        lti_tool_configuration_mock.objects.filter.assert_not_called()
-        lti_tool_configuration_mock.objects.filter.return_value.first.assert_not_called()
-        course_access_conf_queryset_mock.is_course_id_allowed.assert_not_called()
-
-    @patch(f'{MODULE_PATH}._')
-    def test_without_course_access_configuration(
-        self,
-        gettext_mock: MagicMock,
-        lti_tool_configuration_mock: MagicMock,
-        tool_config_mock: MagicMock,
-        course_access_configuration_switch_mock: MagicMock,
-    ):
-        """Test without CourseAccessConfiguration instance."""
-        course_access_configuration_switch_mock.is_enabled.return_value = True
-        lti_tool_configuration_mock.objects.filter.return_value.first.return_value = None
-
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().check_course_access_permission(COURSE_ID, ISS, AUD)
-
-        gettext_mock.assert_called_once_with(
-            f'LTI tool configuration for {tool_config_mock().get_lti_tool().title} not found.',
-        )
+        self.lti_tool_configuration.is_course_id_allowed.assert_not_called()
 
     @patch(f'{MODULE_PATH}._')
     def test_with_disallowed_course_id(
         self,
         gettext_mock: MagicMock,
-        lti_tool_configuration_mock: MagicMock,
-        tool_config_mock: MagicMock,  # pylint: disable=unused-argument
         course_access_configuration_switch_mock: MagicMock,
     ):
-        """Test with disallowed course ID."""
-        course_access_configuration_switch_mock.is_enabled.return_value = True
-        course_access_conf_queryset_mock = (
-            lti_tool_configuration_mock.objects
-            .filter.return_value
-            .first.return_value
-        )
-        course_access_conf_queryset_mock.is_course_id_allowed.return_value = False
+        """Test with disallowed Course ID."""
+        self.lti_tool_configuration.is_course_id_allowed.return_value = False
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().check_course_access_permission(COURSE_ID, ISS, AUD)
-        course_access_conf_queryset_mock.is_course_id_allowed.assert_called_once_with(COURSE_ID)
-        gettext_mock.assert_called_once_with(
-            f'Course ID {COURSE_ID} is not allowed.',
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.check_course_access_permission(
+                COURSE_ID,
+                self.lti_tool_configuration,
+            )
+
+        course_access_configuration_switch_mock.is_enabled.assert_called_once_with()
+        self.lti_tool_configuration.is_course_id_allowed.assert_called_once_with(COURSE_ID)
+        gettext_mock.assert_called_once_with(f'Course ID {COURSE_ID} is not allowed.')
+
+
+@patch.object(LtiProfile.objects, 'create')
+class TestResourceLinkLaunchViewCreateLtiProfile(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.create_lti_profile method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.request = MagicMock(user=self.user)
+
+    def test_not_allows_linking_user(
+        self,
+        lti_profile_create_mock: MagicMock,
+    ):
+        """Test allow_linking_user is False."""
+        self.lti_tool_configuration.allows_linking_user.return_value = False
+
+        self.assertEqual(
+            self.view_class().create_lti_profile(
+                self.request,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+            lti_profile_create_mock.return_value,
+        )
+        self.lti_tool_configuration.allows_linking_user.assert_called_once_with()
+        lti_profile_create_mock.assert_called_once_with(
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+            pii=PII,
+        )
+
+    def test_link_user_action_and_user_authenticated(
+        self,
+        lti_profile_create_mock: MagicMock,
+    ):
+        """Test request user_action is 'link' and request.user is authenticated."""
+        self.request.GET = {'user_action': 'link'}
+
+        self.assertEqual(
+            self.view_class().create_lti_profile(
+                self.request,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+            lti_profile_create_mock.return_value,
+        )
+        self.lti_tool_configuration.allows_linking_user.assert_called_once_with()
+        lti_profile_create_mock.assert_called_once_with(
+            user=self.request.user,
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+            pii=PII,
+        )
+
+    def test_create_user_action_and_not_requires_linking_user(
+        self,
+        lti_profile_create_mock: MagicMock,
+    ):
+        """Test request user_action is 'create' and requires_linking_user is False."""
+        self.request.GET = {'user_action': 'create'}
+        self.lti_tool_configuration.requires_linking_user.return_value = False
+
+        self.assertEqual(
+            self.view_class().create_lti_profile(
+                self.request,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+            lti_profile_create_mock.return_value,
+        )
+        self.lti_tool_configuration.allows_linking_user.assert_called_once_with()
+        self.lti_tool_configuration.requires_linking_user.assert_called_once_with()
+        lti_profile_create_mock.assert_called_once_with(
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+            pii=PII,
+        )
+
+    def test_allows_linking_user_without_action(
+        self,
+        lti_profile_create_mock: MagicMock,
+    ):
+        """Test allow_linking_user is True and there is no request user_action."""
+        self.lti_tool_configuration.allow_linking_user.return_value = False
+
+        self.assertIsNone(
+            self.view_class().create_lti_profile(
+                self.request,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+        )
+        self.lti_tool_configuration.allows_linking_user.assert_called_once_with()
+        self.lti_tool_configuration.requires_linking_user.assert_not_called()
+        lti_profile_create_mock.assert_not_called()
+
+
+@patch.object(ResourceLinkLaunchView, 'create_lti_profile')
+@patch.object(LtiProfile.objects, 'get')
+class TestResourceLinkLaunchViewGetOrCreateLtiProfile(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.get_or_create_lti_profile method."""
+
+    def test_with_lti_profile(
+        self,
+        lti_profile_get_mock: MagicMock,
+        create_lti_profile_mock: MagicMock,
+    ):
+        """Test with existing LtiProfile."""
+        self.assertEqual(
+            self.view_class().get_or_create_lti_profile(
+                None,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+            lti_profile_get_mock.return_value,
+        )
+        lti_profile_get_mock.assert_called_once_with(
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+        )
+        self.assertEqual(lti_profile_get_mock().pii, PII)
+        lti_profile_get_mock().save.assert_called_once_with()
+        create_lti_profile_mock.assert_not_called()
+
+    def test_without_lti_profile(
+        self,
+        lti_profile_get_mock: MagicMock,
+        create_lti_profile_mock: MagicMock,
+    ):
+        """Test without existing LtiProfile."""
+        lti_profile_get_mock.side_effect = LtiProfile.DoesNotExist
+
+        self.assertEqual(
+            self.view_class().get_or_create_lti_profile(
+                None,
+                ISS,
+                AUD,
+                SUB,
+                PII,
+                self.lti_tool_configuration,
+            ),
+            create_lti_profile_mock.return_value,
+        )
+        lti_profile_get_mock.assert_called_once_with(
+            platform_id=ISS,
+            client_id=AUD,
+            subject_id=SUB,
+        )
+        lti_profile_get_mock.return_value.save.assert_not_called()
+        create_lti_profile_mock.assert_called_once_with(
+            None,
+            ISS,
+            AUD,
+            SUB,
+            PII,
+            self.lti_tool_configuration,
+        )
+
+
+@patch(f'{MODULE_PATH}.render')
+class TestResourceLinkLaunchViewRenderLoginPrompt(ResourceLinkLaunchViewBaseTestCase):
+    """Test ResourceLinkLaunchView.render_login_prompt method."""
+
+    def test_render_template(self, render_mock: MagicMock):
+        """Test render template."""
+        self.assertEqual(
+            self.view_class().render_login_prompt(
+                None,
+                self.message,
+                self.lti_tool_configuration,
+            ),
+            render_mock.return_value,
+        )
+        self.message.get_launch_id.assert_called_once_with()
+        self.message.get_launch_id().replace.assert_called_once_with('lti1p3-launch-', '')
+        render_mock.assert_called_once_with(
+            None,
+            self.view_class.LOGIN_PROMPT_TEMPLATE,
+            {
+                'launch_id': self.message.get_launch_id().replace(),
+                'lti_tool_configuration': self.lti_tool_configuration,
+            },
         )
 
 
@@ -498,7 +789,7 @@ class TestResourceLinkLaunchViewAuthenticateAndLogin(ResourceLinkLaunchViewBaseT
         """Test with user."""
         authenticate_mock.return_value = self.user
 
-        self.assertEqual(self.view_class().authenticate_and_login(None, **IDENTITY_CLAIMS), self.user)
+        self.assertEqual(self.view_class.authenticate_and_login(None, **IDENTITY_CLAIMS), self.user)
         authenticate_mock.assert_called_once_with(None, **IDENTITY_CLAIMS)
         login_mock.assert_called_once_with(None, self.user)
         mark_user_change_as_expected_mock.assert_called_once_with(self.user.id)
@@ -512,11 +803,12 @@ class TestResourceLinkLaunchViewAuthenticateAndLogin(ResourceLinkLaunchViewBaseT
         """Test without user."""
         authenticate_mock.return_value = None
 
-        with self.assertRaises(LtiToolLaunchException) as ex:
-            self.view_class().authenticate_and_login(None, **IDENTITY_CLAIMS)
+        with self.assertRaises(ResourceLinkException) as ex:
+            self.view_class.authenticate_and_login(None, **IDENTITY_CLAIMS)
+
         self.assertEqual(
             str(ex.exception),
-            'Profile authentication failed.',
+            'LtiProfile authentication failed.',
         )
         authenticate_mock.assert_called_once_with(None, **IDENTITY_CLAIMS)
         login_mock.assert_not_called()
@@ -529,7 +821,7 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
 
     def test_with_enrollment(self, course_enrollment_mock: MagicMock):
         """Test with enrollment."""
-        self.assertEqual(self.view_class().enroll(None, self.user, COURSE_KEY), None)
+        self.assertEqual(self.view_class.enroll(None, self.user, COURSE_KEY), None)
         course_enrollment_mock().get_enrollment.assert_called_once_with(self.user, COURSE_KEY)
         course_enrollment_mock().enroll.assert_not_called()
 
@@ -537,7 +829,7 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
         """Test without enrollment."""
         course_enrollment_mock().get_enrollment.return_value = None
 
-        self.assertEqual(self.view_class().enroll(None, self.user, COURSE_KEY), None)
+        self.assertEqual(self.view_class.enroll(None, self.user, COURSE_KEY), None)
         course_enrollment_mock().get_enrollment.assert_called_once_with(self.user, COURSE_KEY)
         course_enrollment_mock().enroll.assert_called_once_with(
             user=self.user,
@@ -555,8 +847,9 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
         """Test with CourseEnrollmentException."""
         course_enrollment_mock.side_effect = course_enrollment_exception()
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().enroll(None, self.user, COURSE_KEY)
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.enroll(None, self.user, COURSE_KEY)
+
         gettext_mock.assert_called_once_with('Course enrollment failed: ')
 
 
@@ -622,7 +915,7 @@ class TestResourceLinkLaunchViewGetCourseLaunchResponse(ResourceLinkLaunchViewBa
         """Test with enabled `ALLOW_COMPLETE_COURSE_LAUNCH` switch."""
         allow_complete_course_launch_mock.is_enabled.return_value = True
 
-        self.assertEqual(self.view_class().get_course_launch_response(COURSE_ID), redirect_mock.return_value)
+        self.assertEqual(self.view_class.get_course_launch_response(COURSE_ID), redirect_mock.return_value)
         allow_complete_course_launch_mock.is_enabled.assert_called_once_with()
         configuration_helpers().get_value.assert_called_once_with(
             "LEARNING_MICROFRONTEND_URL",
@@ -644,8 +937,8 @@ class TestResourceLinkLaunchViewGetCourseLaunchResponse(ResourceLinkLaunchViewBa
         """Test with disabled `ALLOW_COMPLETE_COURSE_LAUNCH` switch."""
         allow_complete_course_launch_mock.is_enabled.return_value = False
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().get_course_launch_response(COURSE_ID)
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.get_course_launch_response(COURSE_ID)
 
         allow_complete_course_launch_mock.is_enabled.assert_called_once_with()
         gettext_mock.assert_called_once_with('Complete course launches are not enabled.')
@@ -668,7 +961,7 @@ class TestResourceLinkLaunchViewHandleAgs(ResourceLinkLaunchViewBaseTestCase):
             },
         }
 
-        self.view_class().handle_ags(
+        self.view_class.handle_ags(
             launch_message,
             launch_data,
             LTI_PROFILE,
@@ -699,8 +992,8 @@ class TestResourceLinkLaunchViewHandleAgs(ResourceLinkLaunchViewBaseTestCase):
         }
         lti_graded_resource_mock.objects.get_or_create.side_effect = val_error
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().handle_ags(
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.handle_ags(
                 launch_message,
                 launch_data,
                 LTI_PROFILE,
@@ -726,7 +1019,7 @@ class TestResourceLinkLaunchViewHandleAgs(ResourceLinkLaunchViewBaseTestCase):
             },
         }
 
-        self.view_class().handle_ags(
+        self.view_class.handle_ags(
             launch_message,
             launch_data,
             LTI_PROFILE,
@@ -748,8 +1041,8 @@ class TestResourceLinkLaunchViewHandleAgs(ResourceLinkLaunchViewBaseTestCase):
             },
         }
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().handle_ags(
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.handle_ags(
                 launch_message,
                 launch_data,
                 LTI_PROFILE,
@@ -770,8 +1063,8 @@ class TestResourceLinkLaunchViewHandleAgs(ResourceLinkLaunchViewBaseTestCase):
             },
         }
 
-        with self.assertRaises(LtiToolLaunchException):
-            self.view_class().handle_ags(
+        with self.assertRaises(ResourceLinkException):
+            self.view_class.handle_ags(
                 launch_message,
                 launch_data,
                 LTI_PROFILE,

--- a/openedx_lti_tool_plugin/resource_link_launch/utils.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/utils.py
@@ -1,0 +1,25 @@
+"""Utilities."""
+from django.utils.translation import gettext as _
+from pylti1p3.contrib.django import DjangoMessageLaunch
+
+from openedx_lti_tool_plugin.resource_link_launch.exceptions import ResourceLinkException
+
+
+def validate_resource_link_message(message: DjangoMessageLaunch):
+    """
+    Validate LtiResourceLinkRequest message.
+
+    Args:
+        message: DjangoMessageLaunch object.
+
+    Raises:
+        ResourceLinkException: If message_type is not LtiResourceLinkRequest.
+
+    .. _LTI 1.3 Advantage Tool implementation in Python - LTI Message Launches:
+        https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
+
+    """
+    if not message.is_resource_launch():
+        raise ResourceLinkException(
+            _('Message type is not LtiResourceLinkRequest.'),
+        )

--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
@@ -1,0 +1,6 @@
+{# TODO: This needs to be replaced with a prompt to ask the user to login or create a new User. #}
+<ul>
+    <li>Launch ID: {{ launch_id }}</li>
+    <li>Requires Linking User: {{ lti_tool_configuration.requires_linking_user }}</li>
+    <li>User Provisioning Mode: {{ lti_tool_configuration.user_provisioning_mode }}</li>
+</ul>

--- a/openedx_lti_tool_plugin/tests/test_mixins.py
+++ b/openedx_lti_tool_plugin/tests/test_mixins.py
@@ -39,6 +39,26 @@ class TestLTIToolMixin(TestCase):
     @patch.object(LTIToolMixin, 'tool_config', new_callable=PropertyMock)
     @patch.object(LTIToolMixin, 'tool_storage', new_callable=PropertyMock)
     @patch(f'{MODULE_PATH}.DjangoMessageLaunch')
+    def test_get_message(
+        self,
+        message_launch_mock: MagicMock,
+        tool_storage_mock: MagicMock,
+        tool_conf_mock: MagicMock,
+    ):
+        """Test get_message method."""
+        self.assertEqual(
+            self.mixin_class().get_message(self.request),
+            message_launch_mock.return_value,
+        )
+        message_launch_mock.assert_called_once_with(
+            self.request,
+            tool_conf_mock(),
+            launch_data_storage=tool_storage_mock(),
+        )
+
+    @patch.object(LTIToolMixin, 'tool_config', new_callable=PropertyMock)
+    @patch.object(LTIToolMixin, 'tool_storage', new_callable=PropertyMock)
+    @patch(f'{MODULE_PATH}.DjangoMessageLaunch')
     def test_get_message_from_cache(
         self,
         message_launch_mock: MagicMock,

--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -430,6 +430,7 @@ class TestLtiProfile(TestCase):
         )
 
 
+@ddt.ddt
 class TestLtiToolConfiguration(TestCase):
     """Test LTI tool configuration model."""
 
@@ -571,6 +572,30 @@ class TestLtiToolConfiguration(TestCase):
 
         self.assertFalse(self.tool_configuration.is_course_id_allowed('id-3'))
         json_loads_mock.assert_called_once_with(self.tool_configuration.allowed_course_ids)
+
+    @ddt.data(
+        (LtiToolConfiguration.UserProvisioningMode.EXISTING_ONLY, True),
+        (LtiToolConfiguration.UserProvisioningMode.EXISTING_AND_NEW, True),
+        (LtiToolConfiguration.UserProvisioningMode.NEW_ACCOUNTS_ONLY, False),
+    )
+    @ddt.unpack
+    def test_allows_linking_user(self, value: str, result: bool):
+        """Test allows_linking_user method."""
+        self.tool_configuration.user_provisioning_mode = value
+
+        self.assertEqual(self.tool_configuration.allows_linking_user(), result)
+
+    @ddt.data(
+        (LtiToolConfiguration.UserProvisioningMode.EXISTING_ONLY, True),
+        (LtiToolConfiguration.UserProvisioningMode.EXISTING_AND_NEW, False),
+        (LtiToolConfiguration.UserProvisioningMode.NEW_ACCOUNTS_ONLY, False),
+    )
+    @ddt.unpack
+    def test_requires_linking_user(self, value: str, result: bool):
+        """Test requires_linking_user method."""
+        self.tool_configuration.user_provisioning_mode = value
+
+        self.assertEqual(self.tool_configuration.requires_linking_user(), result)
 
     def test_str_method(self):
         """Test __str__ method return value."""


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2213

## Description

This PR adds the functionality for user provisioning modes to the ResourceLinkLaunchView, additionally a get_message method was added to the LTIToolMixin and the DeepLinkingView was updated to make use of such method, additionally the DeepLinkingException was updated to inherit from the LtiToolException class and the docstrings of the modified code was updated.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Click on the dropdown next to the "Connect" button on the top navbar.
17. Click on "Open in iframe" or "Open in new window".
18. The launch should redirect you to the requested course on the learning MFE.
19. Go to Django Admin > Open edX LTI Tool Plugin > LTI tool configurations.
20. Modify the created LTI tool configuration for saLTIre by setting the "User provisioning mode" to "Existing and new (prompt)".
21. Go to "User" on the left sidebar of saLTIre.
22. Modify the Subject ID.
23. Click on "Save"
24. Click on the dropdown next to the "Connect" button on the top navbar.
25. Click on "Open in iframe" or "Open in new window".
26. The launch should redirect you to the login_prompt.html template.
27. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=create
28. Go to the URL.
29. You should be redirected to the learning MFE with a new User.
30. Repeat steps 21 -25.
31. The launch should render the login_prompt.html template.
32. Go to the Open edX LMS and login to an existing User.
33. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=link
34. Go to the URL.
35. You should be redirected to the learning MFE with the User you where already logged in.
36. Modify the LTI tool configuration "User provisioning mode" to "Existing only (prompt)".
37. Repeat steps 21 -25.
38. The launch should render the login_prompt.html template.
39. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=create
40. Go to the URL.
41. The launch should render the login_prompt.html template.
42. Go to the LMS and login to an existing User.
43. Go to the URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=link
44. You should be redirected to the learning MFE with the User you where already logged in.
45. Repeat the launch with each Subject ID previously used.
46. Each launch should go directly to the learning MFE without rendering the login_prompt.html template.

