### PR TITLE
fix: CI GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,37 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  # Use a fallback github.run_id to avoid a syntax error.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   run_tests:
     name: tests
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.10']
         toxenv: [quality, django32, django40]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Install Dependencies
-      run: make dev-requirements
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Run Tests
-      env:
-        TOXENV: ${{ matrix.toxenv }}
-      run: tox
+      - name: Install Dependencies
+        run: make dev-requirements
+
+      - name: Run Tests
+        env:
+          TOXENV: ${{ matrix.toxenv }}
+        run: tox


### PR DESCRIPTION
## Description

This PR fixes the issue related to the retirement of the Ubuntu 20.04 LTS runner, the runner was removed on 2025-04-15 making our CI workflow fail. For more details, see https://github.com/actions/runner-images/issues/11101. Additionally the checkout and Python setup steps where updated to newer versions.