### PR TITLE
PADV-2309: Modify login_prompt.html template

### DIFF
--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
@@ -1,6 +1,108 @@
-{# TODO: This needs to be replaced with a prompt to ask the user to login or create a new User. #}
-<ul>
-    <li>Launch ID: {{ launch_id }}</li>
-    <li>Requires Linking User: {{ lti_tool_configuration.requires_linking_user }}</li>
-    <li>User Provisioning Mode: {{ lti_tool_configuration.user_provisioning_mode }}</li>
-</ul>
+{% extends 'openedx_lti_tool_plugin/base.html' %}
+{% load i18n %}
+
+{% block title %}{% translate 'Resource Link Launch' %}{% endblock %}
+
+{% block body_content %}
+{{ block.super }}
+<div class='container my-4'>
+  <h2>{% translate 'Welcome!' %}</h2>
+  <div class='alert alert-info alert-block'>
+    {% translate 'It looks like this is your first time here. Please select from one of the following account options.' %}
+  </div>
+  <div class='row'>
+    <div class='col-lg-6 mb-2'>
+      <div class='card'>
+        <div class='card-header'>{% translate 'I have an existing account' %}</div>
+        <div class='card-body'>
+          <h4 class='card-title'>{% translate 'Use existing account' %}</h4>
+          {% if user.is_authenticated %}
+          <p class='card-text'>
+            <span class='text-muted'>{% translate 'You are currently logged in as:' %} </span>
+            {{ user.profile.name }} ({{ user.email }})
+          </p>
+          <button type='button' class='btn btn-primary' data-toggle='modal' data-target='#linkAccountModal'>
+            {% translate 'Link this account' %}
+          </button>
+          <a
+            class='btn btn-light'
+            href='/logout?next={{ request.path }}?launch_id={{ launch_id }}'>
+            {% translate 'Logout' %}
+          </a>
+          {% else %}
+          <p class='card-text text-muted'>{% translate 'Log in to link your existing account.' %}</p>
+          <a
+            class='btn btn-primary'
+            href='/login?next={{ request.path }}?launch_id={{ launch_id }}'>
+            {% translate 'Login' %}
+          </a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    {% if not lti_tool_configuration.requires_linking_user %}
+    <div class='col-lg-6 mb-2'>
+      <div class='card'>
+        <div class='card-header'>{% translate "I'd like to create a new account." %}</div>
+        <div class='card-body'>
+          <h4 class='card-title'>{% translate 'Create account' %}</h4>
+          <p class='card-text text-muted'>{% translate 'Get started with a new account' %}</p>
+          <button type='button' class='btn btn-secondary' data-toggle='modal' data-target='#createAccountModal'>
+            {% translate 'Create an account for me' %}
+          </button>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+  <div class='modal fade' id='linkAccountModal' tabindex='-1' role='dialog' aria-labelledby='linkAccountModalLabel' aria-hidden='true'>
+    <div class='modal-dialog' role='document'>
+      <div class='modal-content'>
+        <div class='modal-header'>
+          <h5 class='modal-title' id='linkAccountModalLabel'>{% translate 'Confirm' %}</h5>
+          <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+            <span aria-hidden='true'>&times;</span>
+          </button>
+        </div>
+        <div class='modal-body'>{% translate 'Are you sure you want to link this account?' %}</div>
+        <div class='modal-footer'>
+          <a
+          class='btn btn-primary'
+          href='{{ request.path }}?launch_id={{ launch_id }}&user_action=link'>
+            {% translate 'Yes' %}
+          </a>
+          <button type='button' class='btn btn-secondary' data-dismiss='modal'>{% translate 'No' %}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class='modal fade' id='createAccountModal' tabindex='-1' role='dialog' aria-labelledby='createAccountModalLabel' aria-hidden='true'>
+    <div class='modal-dialog' role='document'>
+      <div class='modal-content'>
+        <div class='modal-header'>
+          <h5 class='modal-title' id='createAccountModalLabel'>{% translate 'Confirm' %}</h5>
+          <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+            <span aria-hidden='true'>&times;</span>
+          </button>
+        </div>
+        <div class='modal-body'>{% translate 'Are you sure you want to create a new account?' %}</div>
+        <div class='modal-footer'>
+          <a
+          class='btn btn-primary'
+          href='{{ request.path }}?launch_id={{ launch_id }}&user_action=create'>
+            {% translate 'Yes' %}
+          </a>
+          <button type='button' class='btn btn-secondary' data-dismiss='modal'>{% translate 'No' %}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block body_js %}
+{{ block.super }}
+<script src='https://code.jquery.com/jquery-3.3.1.slim.min.js' integrity='sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo' crossorigin='anonymous'></script>
+<script src='https://cdn.jsdelivr.net/npm/popper.js@1.14.3/dist/umd/popper.min.js' integrity='sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49' crossorigin='anonymous'></script>
+<script src='https://cdn.jsdelivr.net/npm/bootstrap@4.1.3/dist/js/bootstrap.min.js' integrity='sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy' crossorigin='anonymous'></script>
+{% endblock %}


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2309

## Description

This PR modifies the login_prompt.html template to include a message requesting the user to either link an existing account or let the plugin create an account for them, this template is rendered by the ResourceLinkLaunchView when the get_or_create_lti_profile method of such view doesn't return an LtiProfile instance.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Click on the dropdown next to the "Connect" button on the top navbar.
17. Click on "Open in iframe" or "Open in new window".
18. The launch should redirect you to the requested course on the learning MFE.
19. Go to Django Admin > Open edX LTI Tool Plugin > LTI tool configurations.
20. Modify the created LTI tool configuration for saLTIre by setting the "User provisioning mode" to "Existing and new (prompt)".
21. Go to "User" on the left sidebar of saLTIre.
22. Modify the Subject ID.
23. Click on "Save"
24. Click on the dropdown next to the "Connect" button on the top navbar.
25. Click on "Open in iframe" or "Open in new window".
26. The launch should redirect you to the login_prompt.html template.
27. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=create
28. Go to the URL.
29. You should be redirected to the learning MFE with a new User.
30. Repeat steps 21 -25.
31. The launch should render the login_prompt.html template.
32. Go to the Open edX LMS and login to an existing User.
33. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=link
34. Go to the URL.
35. You should be redirected to the learning MFE with the User you where already logged in.
36. Modify the LTI tool configuration "User provisioning mode" to "Existing only (prompt)".
37. Repeat steps 21 -25.
38. The launch should render the login_prompt.html template.
39. Copy the launch ID and modify the URL to: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=create
40. Go to the URL.
41. The launch should render the login_prompt.html template.
42. Go to the LMS and login to an existing User.
43. Go to the URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}?launch_id={launch_id}&user_action=link
44. You should be redirected to the learning MFE with the User you where already logged in.
45. Repeat the launch with each Subject ID previously used.
46. Each launch should go directly to the learning MFE without rendering the login_prompt.html template.

