### PR TITLE
PADV-2340: Make user provision use PII email on link

### DIFF
--- a/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
+++ b/openedx_lti_tool_plugin/templates/openedx_lti_tool_plugin/resource_link/login_prompt.html
@@ -17,13 +17,23 @@
         <div class='card-body'>
           <h4 class='card-title'>{% translate 'Use existing account' %}</h4>
           {% if user.is_authenticated %}
-          <p class='card-text'>
-            <span class='text-muted'>{% translate 'You are currently logged in as:' %} </span>
-            {{ user.profile.name }} ({{ user.email }})
-          </p>
+          <div class='card-text'>
+            <p>
+              <span class='text-muted'>{% translate 'You are currently logged in as:' %}</span>
+              {{ user.profile.name }} ({{ user.email }})
+            </p>
+            {% if pii.email and request.user.email != pii.email %}
+            <div class='alert alert-warning alert-block'>
+              {% translate 'Logged account must be using the email:' %} {{ pii.email }}
+            </div>
+            {% endif %}
+          </div>
+          {% if pii.email and request.user.email != pii.email %}
+          {% else %}
           <button type='button' class='btn btn-primary' data-toggle='modal' data-target='#linkAccountModal'>
             {% translate 'Link this account' %}
           </button>
+          {% endif %}
           <a
             class='btn btn-light'
             href='/logout?next={{ request.path }}?launch_id={{ launch_id }}'>


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2340

## Description

This PR modifies the user provisioning feature to make use of the PII email while linking an user, this will make sure that learners cannot link an user with a different email from the email sent on the PII data, if the PII email is not present then there will be no restriction.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True

# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```

14. Go to the saLTIre platform https://saltire.lti.app/platform
15. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

16. Click on the dropdown next to the "Connect" button on the top navbar.
17. Click on "Open in iframe" or "Open in new window".
18. The launch should redirect you to the requested course on the learning MFE.
19. Go to Django Admin > Open edX LTI Tool Plugin > LTI tool configurations.
20. Modify the created LTI tool configuration for saLTIre by setting the "User provisioning mode" to "Existing and new (prompt)".
21. Go to "User" on the left sidebar of saLTIre.
22. Modify the Subject ID.
23. Take note of the "Email" field value.
24. Click on "Save"
25. Click on the dropdown next to the "Connect" button on the top navbar.
26. Click on "Open in iframe" or "Open in new window".
27. The launch should redirect you to the login_prompt.html template.
28. Try to login to an user with en email different from the PII email.
29. The login_prompt.html template should show you an alert warning you that the user cannot be linked.
30. Go to "User" on the left sidebar of saLTIre.
31. Uncheck the "Email" field.
32. Execute the launch again.
33. The launch should allow linking any user.
