### PR TITLE
PADV-2342: Add user provisioning template  setting

### DIFF
--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
@@ -772,10 +772,15 @@ class TestResourceLinkLaunchViewGetOrCreateLtiProfile(ResourceLinkLaunchViewBase
 
 
 @patch(f'{MODULE_PATH}.render')
+@patch(f'{MODULE_PATH}.configuration_helpers')
 class TestResourceLinkLaunchViewRenderLoginPrompt(ResourceLinkLaunchViewBaseTestCase):
     """Test ResourceLinkLaunchView.render_login_prompt method."""
 
-    def test_render_template(self, render_mock: MagicMock):
+    def test_render_template(
+        self,
+        configuration_helpers_mock: MagicMock,
+        render_mock: MagicMock,
+    ):
         """Test render template."""
         self.assertEqual(
             self.view_class().render_login_prompt(
@@ -786,11 +791,15 @@ class TestResourceLinkLaunchViewRenderLoginPrompt(ResourceLinkLaunchViewBaseTest
             ),
             render_mock.return_value,
         )
+        configuration_helpers_mock().get_value.assert_called_once_with(
+            'OLTITP_LOGIN_PROMPT_TEMPLATE',
+            settings.OLTITP_LOGIN_PROMPT_TEMPLATE,
+        )
         self.message.get_launch_id.assert_called_once_with()
         self.message.get_launch_id().replace.assert_called_once_with('lti1p3-launch-', '')
         render_mock.assert_called_once_with(
             None,
-            self.view_class.LOGIN_PROMPT_TEMPLATE,
+            configuration_helpers_mock().get_value(),
             {
                 'launch_id': self.message.get_launch_id().replace(),
                 'lti_tool_configuration': self.lti_tool_configuration,

--- a/openedx_lti_tool_plugin/resource_link_launch/views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/views.py
@@ -49,9 +49,6 @@ class ResourceLinkLaunchView(LTIToolView):
 
     This view handles the LTI resource link launch request workflow.
 
-    Attributes:
-        LOGIN_PROMPT_TEMPLATE (str): Login prompt template name.
-
     .. _LTI Core Specification 1.3 - Resource link launch request message:
         https://www.imsglobal.org/spec/lti/v1p3#resource-link-launch-request-message
 
@@ -59,8 +56,6 @@ class ResourceLinkLaunchView(LTIToolView):
         https://github.com/dmitry-viskov/pylti1.3?tab=readme-ov-file#lti-message-launches
 
     """
-
-    LOGIN_PROMPT_TEMPLATE = 'openedx_lti_tool_plugin/resource_link/login_prompt.html'
 
     def get(self, request: HttpRequest) -> Union[HttpResponseRedirect, LoggedHttpResponseBadRequest]:
         """HTTP GET request method.
@@ -445,7 +440,10 @@ class ResourceLinkLaunchView(LTIToolView):
         """
         return render(
             request,
-            self.LOGIN_PROMPT_TEMPLATE,
+            configuration_helpers().get_value(
+                'OLTITP_LOGIN_PROMPT_TEMPLATE',
+                settings.OLTITP_LOGIN_PROMPT_TEMPLATE,
+            ),
             {
                 'launch_id': message.get_launch_id().replace('lti1p3-launch-', ''),
                 'lti_tool_configuration': lti_tool_configuration,

--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -43,6 +43,9 @@ def plugin_settings(settings: LazySettings):
     # General settings
     settings.OLTITP_ENABLE_LTI_TOOL = False
 
+    # Resource link launch settings
+    settings.OLTITP_LOGIN_PROMPT_TEMPLATE = 'openedx_lti_tool_plugin/resource_link/login_prompt.html'
+
     # Deep linking settings
     settings.OLTITP_DEEP_LINKING_FORM_TEMPLATE = 'openedx_lti_tool_plugin/deep_linking/form.html'
 

--- a/openedx_lti_tool_plugin/settings/test.py
+++ b/openedx_lti_tool_plugin/settings/test.py
@@ -69,6 +69,9 @@ LEARNING_MICROFRONTEND_URL = 'example.com'
 # General settings
 OLTITP_ENABLE_LTI_TOOL = True
 
+# Resource link launch settings
+OLTITP_LOGIN_PROMPT_TEMPLATE = 'openedx_lti_tool_plugin/resource_link/login_prompt.html'
+
 # Deep linking settings
 OLTITP_DEEP_LINKING_FORM_TEMPLATE = 'openedx_lti_tool_plugin/deep_linking/form.html'
 


### PR DESCRIPTION
## Tickets

- https://pearson.atlassian.net/browse/PADV-2342

## Description

This PR adds a `OLTITP_LOGIN_PROMPT_TEMPLATE` setting that allows modifying the template used for the user provisioning feature in LTI 1.3 resource link launches.

## Testing:

1. Run the LMS: `make dev.up.lms`.
2. Run the learning MFE on the host machine: `npm run start`.
3. Install `openedx_lti_tool_plugin` on the LMS.
4. Run ngrok or any other similar service on LMS: `ngrok http 18000`
5. Run ngrok or any other similar service on learning MFE: `ngrok http 2000`
6. Add required settings to LMS.
	
```
# Enable LTI Tool Provider Plugin.
OLTITP_ENABLE_LTI_TOOL = True
# Set custom template path.
OLTITP_LOGIN_PROMPT_TEMPLATE = 'test/template.html'  
# Cookies settings.
SHARED_COOKIE_DOMAIN = ".ngrok.io"  # Replace .ngrok.io with the domain of the service used to expose the LMS and learning MFE if using another service other than ngrok.
# MFE config API settings.
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
```

7. Create a site for your external LMS address: http://localhost:18000/admin/sites/site/add/.
8. Create a site configuration for your site: http://localhost:18000/admin/site_configuration/siteconfiguration/add/

```
  {
      "SESSION_COOKIE_DOMAIN": ".ngrok.io", # This should be the same value has SHARED_COOKIE_DOMAIN setting.
      "LEARNING_MICROFRONTEND_URL": "https://learning-mfe.ngrok.io",
      "MFE_CONFIG": {
          "LMS_BASE_URL": "https://lms.ngrok.io",
          "LOGIN_URL": "https://lms.ngrok.io/login",
          "LOGOUT_URL": "https://lms.ngrok.io/logout",
          "MARKETING_SITE_BASE_URL": "https://lms.ngrok.io",
          "BASE_URL": "lms.ngrok.io",
          "LEARNING_BASE_URL": "https://learning-mfe.ngrok.io,
          "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://lms.ngrok.io/login_refresh"
      }
  }
```

9. Restart the LMS: `make dev.restart-container.lms`.
10. Modify the learning MFE `webpack.dev.config.js` file (create one if not file exists.):

```
const path = require('path');
const { createConfig } = require('@edx/frontend-build');
const config = createConfig('webpack-dev', {
    devServer: {
      allowedHosts: 'all',
    },
});
config.resolve.modules = [
  path.resolve(__dirname, './src'),
  'node_modules',
];
module.exports = config;
```

11. Modify the learning MFE `.env.development` file and add these variables:

```
APP_ID='learning'
MFE_CONFIG_API_URL='https://lms.ngrok.io/api/mfe_config/v1'
```

12. Create a new LTI 1.3 tool key config: http://localhost:18000/admin/lti1p3_tool_config/ltitoolkey/add/ (You can use IMS RI to create a key pair: https://lti-ri.imsglobal.org/keygen/index)
13. Create a new LTI 1.3 tool config: http://localhost:18000/admin/lti1p3_tool_config/ltitool/add/

```
Issuer: https://saltire.lti.app/platform
Client id: saltire.lti.app
Auth login: url: https://saltire.lti.app/platform/auth
Auth token url: https://saltire.lti.app/platform/token/sda42bb0cf2352259a367a404d48d54e8
Key set url: https://saltire.lti.app/platform/jwks/sda42bb0cf2352259a367a404d48d54e8
Deployment ids: ["cLWwj9cbmkSrCNsckEFBmA"]
```
14. Go to Django Admin > Open edX LTI Tool Plugin > LTI tool configurations.
15. Modify the created LTI tool configuration for saLTIre by setting the "User provisioning mode" to "Existing and new (prompt)".
16. Go to the saLTIre platform https://saltire.lti.app/platform
17. Go to "Security Model" on the left sidebar and set these settings:

```
Message URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Initiate login URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/login
Redirection URI(s): https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/launch/{course_id}
Public keyset URL: https://lms.ngrok.io/openedx_lti_tool_plugin/1.3/pub/jwks
```

18. Click on the dropdown next to the "Connect" button on the top navbar.
19. Click on "Open in iframe" or "Open in new window".
20. The template set on OLTITP_LOGIN_PROMPT_TEMPLATE setting should be rendered.
