### PR TITLE
fix: CourseEnrollment.enroll call

### DIFF
--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
@@ -146,7 +146,6 @@ class TestResourceLinkLaunchViewPost(ResourceLinkLaunchViewBaseTestCase):
         render_login_prompt_mock.assert_not_called()
         authenticate_and_login_mock.assert_called_once_with(self.request, ISS, AUD, SUB)
         enroll_mock.assert_called_once_with(
-            self.request,
             authenticate_and_login_mock(),
             self.course_key,
         )
@@ -846,7 +845,7 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
 
     def test_with_enrollment(self, course_enrollment_mock: MagicMock):
         """Test with enrollment."""
-        self.assertEqual(self.view_class.enroll(None, self.user, COURSE_KEY), None)
+        self.assertEqual(self.view_class.enroll(self.user, COURSE_KEY), None)
         course_enrollment_mock().get_enrollment.assert_called_once_with(self.user, COURSE_KEY)
         course_enrollment_mock().enroll.assert_not_called()
 
@@ -854,13 +853,12 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
         """Test without enrollment."""
         course_enrollment_mock().get_enrollment.return_value = None
 
-        self.assertEqual(self.view_class.enroll(None, self.user, COURSE_KEY), None)
+        self.assertEqual(self.view_class.enroll(self.user, COURSE_KEY), None)
         course_enrollment_mock().get_enrollment.assert_called_once_with(self.user, COURSE_KEY)
         course_enrollment_mock().enroll.assert_called_once_with(
             user=self.user,
             course_key=COURSE_KEY,
             check_access=True,
-            request=None,
         )
 
     @patch(f'{MODULE_PATH}._')
@@ -873,7 +871,7 @@ class TestResourceLinkLaunchViewEnroll(ResourceLinkLaunchViewBaseTestCase):
         course_enrollment_mock.side_effect = course_enrollment_exception()
 
         with self.assertRaises(ResourceLinkException):
-            self.view_class.enroll(None, self.user, COURSE_KEY)
+            self.view_class.enroll(self.user, COURSE_KEY)
 
         gettext_mock.assert_called_once_with('Course enrollment failed: ')
 

--- a/openedx_lti_tool_plugin/resource_link_launch/views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/views.py
@@ -151,7 +151,7 @@ class ResourceLinkLaunchView(LTIToolView):
             user = self.authenticate_and_login(request, iss, aud, sub)
 
             # Enroll User.
-            self.enroll(request, user, course_key)
+            self.enroll(user, course_key)
 
             # Get resource link response.
             response = self.get_launch_response(
@@ -492,11 +492,10 @@ class ResourceLinkLaunchView(LTIToolView):
         return user
 
     @staticmethod
-    def enroll(request: HttpRequest, user: UserT, course_key: str):
+    def enroll(user: UserT, course_key: str):
         """Enroll User to Course.
 
         Args:
-            request: HTTPRequest object.
             user: User instance.
             course_key: Course key string.
 
@@ -510,7 +509,6 @@ class ResourceLinkLaunchView(LTIToolView):
                     user=user,
                     course_key=course_key,
                     check_access=True,
-                    request=request,
                 )
         except course_enrollment_exception() as exc:
             raise ResourceLinkException(_(f'Course enrollment failed: {exc}')) from exc


### PR DESCRIPTION
## Description 

This PR adds a fix to the ulmo version of this plugin, since the ulmo version the CourseEnrollment.enroll method doesn't require sending a request argument, we where executing a call to this method using such argument which was raising an exception making all LTI launches fail with a 500 request, to fix this issue the request argument was removed.

## edx-platform diff

- CourseEnrollment.enroll: https://www.diffchecker.com/es/RJ8zhRxb/
- CourseEnrollment.update_enrollment: https://www.diffchecker.com/es/F5wPgY1u/