### PR TITLE
Modifying some methods to correct the functionality for ulmo

### DIFF
--- a/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/tests/test_views.py
@@ -405,7 +405,7 @@ class TestResourceLinkLaunchViewGetOpaqueKeys(ResourceLinkLaunchViewBaseTestCase
             self.view_class().get_opaque_keys(self.resource_id),
             (
                 usage_key_mock.from_string.return_value.course_key,
-                usage_key_mock.from_string.return_value,
+                usage_key_mock.from_string.return_value.map_into_course.return_value,
             ),
         )
 
@@ -457,7 +457,7 @@ class TestResourceLinkLaunchViewValidateOpaqueKeys(ResourceLinkLaunchViewBaseTes
         self.assertIsNone(self.view_class.validate_opaque_keys(self.course_key, self.usage_key, ''))
         gettext_mock.assert_not_called()
 
-    @ddt.data('chapter', 'sequential', 'course')
+    @ddt.data('chapter', 'course')
     def test_with_invalid_usage_key(self, block_type: str, gettext_mock: MagicMock):
         """Test with invalid usage_key argument."""
         self.usage_key.block_type = block_type
@@ -896,7 +896,7 @@ class TestResourceLinkLaunchViewGetLaunchResponse(ResourceLinkLaunchViewBaseTest
             ),
             set_logged_in_cookies.return_value,
         )
-        redirect_mock.assert_called_once_with('render_xblock', str(self.usage_key.course_key))
+        redirect_mock.assert_called_once_with('render_xblock', str(self.usage_key))
         set_logged_in_cookies.assert_called_once_with(None, redirect_mock(), self.user)
 
     @patch.object(ResourceLinkLaunchView, 'get_course_launch_response')

--- a/openedx_lti_tool_plugin/resource_link_launch/views.py
+++ b/openedx_lti_tool_plugin/resource_link_launch/views.py
@@ -234,8 +234,9 @@ class ResourceLinkLaunchView(LTIToolView):
             pass
 
         try:
-            usage_key = UsageKey.from_string(resource_id)
-            course_key = usage_key.course_key
+            _usage_key = UsageKey.from_string(resource_id)
+            course_key = _usage_key.course_key
+            usage_key = _usage_key.map_into_course(course_key)
         except InvalidKeyError:
             pass
 
@@ -256,7 +257,7 @@ class ResourceLinkLaunchView(LTIToolView):
 
         Raises:
             ResourceLinkException: If course_key is not found or
-                if usage_key.block_type is chapter, sequential or course.
+                if usage_key.block_type is chapter or course.
 
         """
         if not course_key:
@@ -266,7 +267,7 @@ class ResourceLinkLaunchView(LTIToolView):
 
         if (
             usage_key
-            and usage_key.block_type in ['chapter', 'sequential', 'course']
+            and usage_key.block_type in ['chapter', 'course']
         ):
             raise ResourceLinkException(
                 _(f'Invalid UsageKey XBlock type: {usage_key.block_type}'),
@@ -540,7 +541,7 @@ class ResourceLinkLaunchView(LTIToolView):
         response = None
 
         if usage_key:
-            response = redirect('render_xblock', str(usage_key.course_key))
+            response = redirect('render_xblock', str(usage_key))
         else:
             response = self.get_course_launch_response(str(course_key))
 


### PR DESCRIPTION
## Summary

This PR addresses several issues discovered while investigating a bug where rendering a `usage_id` always resulted in a "Not Found" page.

## Changes

- **Fix XBlock rendering:** The root cause was an incorrect rendering approach for `usage_id`s. Updated the implementation to follow the same approach used by the community in the LTI Provider tool ([reference](https://github.com/openedx/openedx-platform/blob/f4a40dc80efffb7543e017ca0c9fdb0a224d2a81/lms/djangoapps/lti_provider/views.py#L217-L241)) while also adding the functionality to use sequentials..
- **Update README:** Corrected the documentation to reflect the proper way to render `usage_id`s.
- **Remove conflicting dependencies:** During image builds, a version conflict was found with `edx-opaque-keys` from `openedx-platform`. Since version control for dependencies managed by Open edX should live in `openedx-platform`, those requirements have been removed from this plugin to avoid conflicts.

## Motivation

The incorrect XBlock rendering was silently causing all `usage_id` render attempts to fail with a 404. Removing the duplicate dependency pins ensures this plugin doesn't conflict with the versions controlled by the Open edX platform.

