### PR TITLE
feat: Add email_prefix username generation strategy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,13 @@ Change Log
 Unreleased
 **********
 
-*
+Added
+=====
+
+- Add ``OLTITP_USERNAME_GENERATION_STRATEGY`` setting to generate the Open edX
+  username from the LTI email claim prefix (``email_prefix`` strategy), with
+  sanitization to Open edX username constraints and an incremental numeric
+  suffix on collision. Defaults to the legacy ``uuid`` strategy.
 
 0.4.1 - 2026-06-18
 ********************

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ LMS Settings
 
 - `OLTITP_ENABLE_LTI_TOOL`: Enables or disables the LTI tool plugin.
 - `LtiAuthenticationBackend`: Class needed to be added to AUTHENTICATION_BACKENDS.
+- `OLTITP_USERNAME_GENERATION_STRATEGY`: Strategy used to generate the Open edX username on LTI launch. `'uuid'` (default) keeps the legacy short-UUID based username. `'email_prefix'` derives a readable username from the email claim prefix (text before `@`), sanitized to Open edX username constraints (lowercase, alphanumeric, max length), adding an incremental numeric suffix on collision (jsmith, jsmith2, jsmith3, ...). Falls back to the `'uuid'` behavior when no email is present in the LTI payload.
 
 Django Waffle Switches
 ======================

--- a/openedx_lti_tool_plugin/models.py
+++ b/openedx_lti_tool_plugin/models.py
@@ -5,6 +5,7 @@ import uuid
 from typing import TypeVar
 
 import shortuuid
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -27,6 +28,12 @@ from openedx_lti_tool_plugin.waffle import COURSE_ACCESS_CONFIGURATION
 UserT = TypeVar('UserT', bound=AbstractBaseUser)
 User = get_user_model()
 UserProfile = user_profile()
+
+# Maximum length allowed for an Open edX username.
+USERNAME_MAX_LENGTH = 30
+# Username generation strategies for OLTITP_USERNAME_GENERATION_STRATEGY setting.
+USERNAME_STRATEGY_UUID = 'uuid'
+USERNAME_STRATEGY_EMAIL_PREFIX = 'email_prefix'
 
 
 class LtiProfile(models.Model):
@@ -159,11 +166,44 @@ class LtiProfile(models.Model):
 
     @property
     def username(self) -> str:
-        """str: Username."""
+        """str: Username.
+
+        The username is generated according to the
+        OLTITP_USERNAME_GENERATION_STRATEGY setting:
+
+        - 'uuid' (default): legacy short-UUID based username.
+        - 'email_prefix': readable username derived from the email claim prefix,
+          falling back to the 'uuid' strategy when no email is present.
+
+        Returns:
+            Generated username string.
+
+        """
         # Return from user field.
         if getattr(self, 'user', None):
             return self.user.username
 
+        strategy = getattr(
+            settings,
+            'OLTITP_USERNAME_GENERATION_STRATEGY',
+            USERNAME_STRATEGY_UUID,
+        )
+
+        # Return using email prefix, falling back to uuid strategy.
+        if strategy == USERNAME_STRATEGY_EMAIL_PREFIX:
+            if username := self.username_from_email_prefix():
+                return username
+
+        return self.username_from_uuid()
+
+    def username_from_uuid(self) -> str:
+        """Generate username from name and short_uuid (legacy behavior).
+
+        Returns:
+            Username built with name first word and short_uuid, or short_uuid
+            only when no name is available.
+
+        """
         try:
             # Return using name and short_uuid.
             name = self.name.split()
@@ -174,6 +214,53 @@ class LtiProfile(models.Model):
         except IndexError:
             # Return using short_uuid.
             return f'{self.short_uuid}'
+
+    def username_from_email_prefix(self) -> str:
+        """Generate a readable username from the LTI email claim prefix.
+
+        The prefix (text before '@') is sanitized to comply with Open edX
+        username constraints (lowercase, alphanumeric, max length) and made
+        unique against existing users.
+
+        Returns:
+            Sanitized and collision-free username, or an empty string when no
+            usable email prefix is present (signaling a fallback to the uuid
+            strategy).
+
+        """
+        email = self.pii.get('email', '')
+        prefix = email.split('@')[0] if '@' in email else ''
+        base = re.sub(r'[\W_]+', '', prefix).lower()[:USERNAME_MAX_LENGTH]
+
+        if not base:
+            return ''
+
+        return self.get_available_username(base)
+
+    @staticmethod
+    def get_available_username(base: str) -> str:
+        """Return an available username based on a base string.
+
+        Adds an incremental numeric suffix when the username already exists
+        (base, base2, base3, ...), keeping the result within
+        USERNAME_MAX_LENGTH.
+
+        Args:
+            base: Base username string.
+
+        Returns:
+            An available username string.
+
+        """
+        username = base
+        suffix = 1
+
+        while User.objects.filter(username=username).exists():
+            suffix += 1
+            tail = str(suffix)
+            username = f'{base[:USERNAME_MAX_LENGTH - len(tail)]}{tail}'
+
+        return username
 
     @property
     def user_profile_field_values(self) -> dict:

--- a/openedx_lti_tool_plugin/settings/common.py
+++ b/openedx_lti_tool_plugin/settings/common.py
@@ -43,6 +43,9 @@ def plugin_settings(settings: LazySettings):
     # General settings
     settings.OLTITP_ENABLE_LTI_TOOL = False
 
+    # Username generation settings
+    settings.OLTITP_USERNAME_GENERATION_STRATEGY = 'uuid'  # 'uuid' | 'email_prefix'
+
     # Deep linking settings
     settings.OLTITP_DEEP_LINKING_FORM_TEMPLATE = 'openedx_lti_tool_plugin/deep_linking/form.html'
 

--- a/openedx_lti_tool_plugin/tests/test_models.py
+++ b/openedx_lti_tool_plugin/tests/test_models.py
@@ -9,13 +9,20 @@ import ddt
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import signals
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from pylti1p3.contrib.django.lti1p3_tool_config.models import LtiTool, LtiToolKey
 
 from openedx_lti_tool_plugin.apps import OpenEdxLtiToolPluginConfig as app_config
-from openedx_lti_tool_plugin.models import CourseContext, CourseContextQuerySet, LtiProfile, LtiToolConfiguration
+from openedx_lti_tool_plugin.models import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_STRATEGY_EMAIL_PREFIX,
+    CourseContext,
+    CourseContextQuerySet,
+    LtiProfile,
+    LtiToolConfiguration,
+)
 from openedx_lti_tool_plugin.tests import AUD, ISS, ORG, SUB
 
 MODULE_PATH = 'openedx_lti_tool_plugin.models'
@@ -388,6 +395,69 @@ class TestLtiProfile(TestCase):
             self.lti_profile.username,
             f'{name_return}{self.lti_profile.short_uuid}',
         )
+
+    @override_settings(OLTITP_USERNAME_GENERATION_STRATEGY=USERNAME_STRATEGY_EMAIL_PREFIX)
+    @patch.object(LtiProfile, 'get_available_username', side_effect=lambda base: base)
+    @ddt.data(
+        ('j.smith@example.com', 'jsmith'),
+        ('John.Smith@example.com', 'johnsmith'),
+        ('a_b-c+d@example.com', 'abcd'),
+        (f'{"x" * 40}@example.com', 'x' * USERNAME_MAX_LENGTH),
+    )
+    @ddt.unpack
+    def test_username_email_prefix_strategy(
+        self,
+        email: str,
+        expected: str,
+        get_available_username_mock: MagicMock,
+    ):
+        """Test username property with email_prefix strategy."""
+        self.lti_profile.user = None
+        self.lti_profile.pii = {'email': email}
+
+        self.assertEqual(self.lti_profile.username, expected)
+        get_available_username_mock.assert_called_once_with(expected)
+
+    @override_settings(OLTITP_USERNAME_GENERATION_STRATEGY=USERNAME_STRATEGY_EMAIL_PREFIX)
+    @ddt.data({}, {'email': ''}, {'email': 'not-an-email'})
+    def test_username_email_prefix_strategy_fallback(self, pii: dict):
+        """Test username email_prefix strategy falls back to uuid without email."""
+        self.lti_profile.user = None
+        self.lti_profile.pii = pii
+
+        self.assertEqual(
+            self.lti_profile.username,
+            self.lti_profile.username_from_uuid(),
+        )
+
+    @patch(f'{MODULE_PATH}.User.objects.filter')
+    @ddt.data(
+        ([False], 'jsmith'),
+        ([True, False], 'jsmith2'),
+        ([True, True, False], 'jsmith3'),
+    )
+    @ddt.unpack
+    def test_get_available_username(
+        self,
+        exists_side_effect: list,
+        expected: str,
+        filter_mock: MagicMock,
+    ):
+        """Test get_available_username adds incremental numeric suffix on collision."""
+        filter_mock.return_value.exists.side_effect = exists_side_effect
+
+        self.assertEqual(LtiProfile.get_available_username('jsmith'), expected)
+
+    @patch(f'{MODULE_PATH}.User.objects.filter')
+    def test_get_available_username_respects_max_length(self, filter_mock: MagicMock):
+        """Test get_available_username keeps suffixed username within max length."""
+        filter_mock.return_value.exists.side_effect = [True, False]
+        base = 'a' * USERNAME_MAX_LENGTH
+
+        result = LtiProfile.get_available_username(base)
+
+        self.assertEqual(len(result), USERNAME_MAX_LENGTH)
+        self.assertTrue(result.endswith('2'))
 
     def test_email_property(self):
         """Test email property."""


### PR DESCRIPTION
## Description

Adds the `OLTITP_USERNAME_GENERATION_STRATEGY` setting to control how the Open edX username is generated on LTI launch.

- **`uuid`** (default): legacy short-UUID based username. Existing behavior is unchanged.
- **`email_prefix`**: derives a readable username from the email claim prefix (text before `@`), sanitized to Open edX username constraints (lowercase, alphanumeric, max 30 chars), with an incremental numeric suffix on collision (`jsmith`, `jsmith2`, `jsmith3`, ...).

When the `email_prefix` strategy is active but no email is present in the LTI payload, it falls back to the legacy `uuid` strategy, so no launch flow breaks.

## Changes

- `settings/common.py`: new `OLTITP_USERNAME_GENERATION_STRATEGY` default.
- `models.py`: module constants (`USERNAME_MAX_LENGTH`, strategy names); `username` property now routes by strategy; new `username_from_uuid()`, `username_from_email_prefix()`, and `get_available_username()` methods.
- `tests/test_models.py`: coverage for both strategies, sanitization, truncation, fallback, and collision handling.
- `README.rst`, `CHANGELOG.rst`: documentation.

## Backward compatibility

Default strategy remains `uuid`; deployments that do not set the new setting keep the current behavior.

## Testing

- `make quality` — pylint 10.00/10, pydocstyle/isort OK.
- `make test` — full suite passing.
